### PR TITLE
Links to the Process document now all point to the 2015 edition

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -162,7 +162,7 @@
 
         <div>
           <h3>Success Criteria</h3>
-          <p>In order to advance to  <a href="http://www.w3.org/2005/10/Process-20051014/tr.html#RecsCR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have at least two independent implementations of each of feature defined in the specification.</p>
+          <p>In order to advance to  <a href="http://www.w3.org/2015/Process-20150901/#RecsCR" title="Proposed Recommendation">Proposed Recommendation</a>, each specification is expected to have at least two independent implementations of each of feature defined in the specification.</p>
           <p>Each specification should contain a section detailing any known security implications for implementers, Web authors, and end users.</p>
         </div>
       </section>
@@ -217,7 +217,7 @@
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all specifications, this Working Group will seek <a href="http://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working Groups, and with the <a href="http://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="http://www.w3.org/2005/10/Process-20051014/tr.html#RecsWD" title="First Public Working Draft">FPWD</a> and <a href="http://www.w3.org/2005/10/Process-20051014/tr.html#RecsCR" title="Candidate Recommendation">CR</a>, and should be issued when major changes occur in a specification.</p>  
+        <p>For all specifications, this Working Group will seek <a href="http://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> for accessibility, internationalization, performance, privacy, and security with the relevant Working Groups, and with the <a href="http://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. Invitation for review must be issued during each major standards-track document transition, including <a href="http://www.w3.org/2015/Process-20150901/#RecsWD" title="First Public Working Draft">FPWD</a> and <a href="http://www.w3.org/2015/Process-20150901/#RecsCR" title="Candidate Recommendation">CR</a>, and should be issued when major changes occur in a specification.</p>
         <p class="issue"><b>Issue:</b> The paragraph above replaces line-item liaisons and dependencies with individual horizontal groups. There's been a suggestion to name and individually link the specific horizontal groups inline, instead of pointing to a page that lists them.</p>
         <p class="issue"><b>Issue:</b> The requirement for an invitation to review before FPWD and CR may seem a bit overly restrictive, but it only requires an invitation, not a review, a commitment to review, or even a response from the horizontal group. This compromise offers early notification without introducing a bottleneck.</p>
 
@@ -335,7 +335,7 @@
           About this Charter
         </h2>
         <p>
-          This charter has been created according to <a href="http://www.w3.org/Consortium/Process/groups#GAGeneral">section 6.2</a> of the <a href="http://www.w3.org/Consortium/Process">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+          This charter has been created according to <a href="http://www.w3.org/Consortium/Process/groups#GAGeneral">section 5.2</a> of the <a href="http://www.w3.org/Consortium/Process">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
         <section id="history">


### PR DESCRIPTION
This pull request should address #7 and #8, fixing the links to the Process document and the incorrect section number.
