### PR TITLE
Update charter-template.html to clarify meaning of public for meetings

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -284,7 +284,8 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this (Working|Interest) Group are conducted in <a href="https://www.w3.org/2015/Process-20150901/#confidentiality-levels">public</a>. Meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository, and may permit direct public contribution requests.
+          Technical discussions for this (Working|Interest) Group are conducted in <a href="https://www.w3.org/2015/Process-20150901/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository, and may permit direct public contribution requests.
+        The meetings themselves are not open to public participation, however.
         </p>
         <p>
           Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">[name]</i> (Working|Interest) Group home page.</a>


### PR DESCRIPTION
Clarify that f2f meetings and phone conferences are not open to public participation, only the records and results are public. Feedback from Ralph on reviewing the CSS charter, applied to this template.
