### PR TITLE
Test-and-commit

### DIFF
--- a/sw-charter.html
+++ b/sw-charter.html
@@ -187,7 +187,7 @@
             The Working Group will deliver the following W3C normative specifications:
           </p>
           <dl>
-            <dt id="service-worker" class="spec"><a href="#">Service Workers</a></dt>
+            <dt id="service-worker" class="spec"><a href="https://w3c.github.io/ServiceWorker/">Service Workers</a></dt>
             <dd>
               <p>This specification defines an API.</p>
 
@@ -235,8 +235,7 @@
 
         <div id="timeline">
           <h3>Timeline</h3>
-            <p class="todo">Put here a timeline view of all deliverables.</p>
-            <ul class="todo">
+            <ul>
               <li>June 2017: First teleconference</li>
               <li>August-September 2017: First face-to-face meeting</li>
               <li>October 2017:  Service Workers 1 Candidate Recommendation</li>
@@ -246,8 +245,6 @@
             </ul>
         </div>
       </section>
-
-
 
       <section id="coordination">
         <h2>Coordination</h2>

--- a/sw-charter.html
+++ b/sw-charter.html
@@ -216,6 +216,13 @@
         <p>The Working group may produce multiple versions of each deliverable, reflecting developments
           in how much of the relevant technology is interoperably implemented.</p>
 
+        <p>
+          The working group intends to use a dual specification editing and testing approach,
+          where all normative specification changes are generally expected to have a corresponding change, either
+          in the form of new tests or modifications to existing tests, or must include the rationale for
+          why test updates are not required for the proposed update.
+        </p>
+
 
         </div>
 


### PR DESCRIPTION
* In 2.1, the first link of "Service Workers" goes no where.
* section 2.3 doesn't need to have a yellow background.
* Please, add a note that the Group intends to adopt a test-and-commit approach (already the case for the SW repo)

