### PR TITLE
Fixing incorrect timeline, defer to w3c process on meetings.

### DIFF
--- a/webassembly.html
+++ b/webassembly.html
@@ -127,20 +127,20 @@
           </tr>
           <tr>
             <th>
-              Meeting Schedule
+              Meetings
             </th>
             <td>
-              <strong>Teleconferences:</strong> We will meet by teleconference
-              approximately once per month. Meetings will be scheduled by
-              consent of the participants. Teleconferenced meetings will be
-              announced on the public mailing list with at least 3 days notice.
+              Meetings will be scheduled in accordance with the
+              <a href="https://www.w3.org/2017/Process-20170301/#GeneralMeetings">
+                W3C Process Document</a>.
+              <br/>
+              <strong>Distributed:</strong> We will meet by teleconference
+              approximately once per month.
               <br/>
               <strong>Face-to-face:</strong>
               We will meet during the W3C’s annual (TPAC) week;
-              additional face-to-face meetings may be scheduled
-              by consent of the participants, usually no more than 3 per year.
-              Face-to-face meetings will be announced on the public mailing
-              list with at least 10 days notice.
+              additional face-to-face meetings may be scheduled,
+              usually no more than 3 per year.
               Teleconference access to face-to-face meetings will be made
               available.
             </td>
@@ -192,7 +192,7 @@
           title="Proposed Recommendation">Proposed Recommendation</a>, the
           WebAssembly specification is expected to have <a
           href="https://www.w3.org/2017/Process-20170301/#implementation-experience">at
-          least two independent implementations</a> of each of feature it
+          least two independent implementations</a> of each feature it
           defines.</p>
           <p>The WebAssembly specification should contain a section detailing
           any known security or privacy implications for implementors, Web
@@ -232,11 +232,15 @@
               web.</p>
               <p class="draft-status"><b>Draft state:</b>
               <a href="https://github.com/WebAssembly/spec/">In progress in WebAssembly CG</a></p>
-              <p class="milestone"><b>Expected completion:</b> Q1 2018</p>
+              <p class="milestone"><b>Expected completion v.1:</b> Q2 2018</p>
+              <p class="milestone"><b>Expected completion v.2:</b> Q4 2018</p>
+              <p class="milestone"><b>Expected completion v.3:</b> Q2 2019</p>
               <p>
               Revisions to the WebAssembly Recommendation will be produced twice
               each year (see <a href="#timeline">the timeline</a>), snapshotting
               changes that have been incrementally adopted by the Working Group.
+              They will include a testsuite and implementation report for the
+              specification.
 
               Each successive version will incrementally incorporate improvements to
               support more machine-level operations, increase performance, or to
@@ -266,7 +270,6 @@
           </p>
           <ul>
             <li>An OCaml reference interpreter</li>
-            <li>Test suite and implementation report for the specification</li>
             <li>Use cases and requirement documents</li>
             <li>“Explainers”, primers, and best-practice documents</li>
           </ul>
@@ -281,7 +284,7 @@
               <li>Q2 2018: First Public Working Draft of WebAssembly v.2</li>
               <li>Q4 2018: Recommendation of WebAssembly v.2</li>
 
-              <li>Q4 2019: First Public Working Draft of WebAssembly v.3</li>
+              <li>Q4 2018: First Public Working Draft of WebAssembly v.3</li>
               <li>Q2 2019: Recommendation of WebAssembly v.3</li>
             </ul>
         </div>


### PR DESCRIPTION
Also add requirement for test suite and implementation report.