### PR TITLE
Adding two more related groups.

### DIFF
--- a/webassembly.html
+++ b/webassembly.html
@@ -317,6 +317,13 @@
             process.</dd>
           </dl>
           <dl>
+            <dt><a href="https://www.w3.org/2008/webapps/">Web Applications Working Group</a></dt>
+            <dd>
+            Coordinate on interoperability, performance, and ergonomics with
+            <a href="https://www.w3.org/TR/IndexedDB/">IndexedDB</a>.
+            </dd>
+          </dl>
+          <dl>
             <dt><a href="https://www.w3.org/WebPlatform/WG/">Web Platform Working Group</a></dt>
             <dd>Coordination on WebAssembly-specific bindings to existing Web
             APIs (or interpreting existing
@@ -337,6 +344,10 @@
             <dt><a href="https://www.khronos.org/">Khronos Group</a></dt>
             <dd>Coordination on WebAssembly-specific bindings to
               <a href="https://www.khronos.org/webgl/wiki">WebGL</a>.</dd>
+          </dl>
+           <dl>
+            <dt><a href="https://www.w3.org/community/gpu/">WebGPU Community Group</a></dt>
+            <dd>Coordinate on WebAssembly interoperability, performance, and ergonomics.</dd>
           </dl>
         </div>
       </section>


### PR DESCRIPTION
I just noticed that these two groups were included in the CG charter, but not the WG charter.
It's probably minor either way, but is it still appropriate to add them?
