### PR TITLE
Switch to HTTPS in 3 URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ can create a draft charter here for public discussion. If you’d like to have
 push access to add a draft charter to the repo,
 [file an issue requesting access](https://github.com/w3c/charter-drafts/issues) or fork this repo to make a pull request.
 
-The template: http://w3c.github.io/charter-drafts/charter-template.html
+See [the template](https://w3c.github.io/charter-drafts/charter-template.html)

--- a/charter-template.html
+++ b/charter-template.html
@@ -153,7 +153,7 @@
           <p>Each specification should contain a section detailing any known security or privacy implications for implementers, Web authors, and end users.</p>
           <p>Testing plans for each specification, starting from the earliest drafts.</p>
           <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
-            Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and 
+            Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
             recommendations for maximising accessibility in implementations.</p>
         </div>
       </section>
@@ -188,12 +188,12 @@
     <p class="todo">Per <a href="https://www.w3.org/2017/Process-20170301/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
       <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
       <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> 
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span>
       <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
     </dd>
               </dl></dl>
-            
-         
+
+
         </div>
 
         <div id="ig-other-deliverables">
@@ -289,7 +289,7 @@
           Most <i class="todo">[name]</i> (Working|Interest) Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="http://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
+          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
           <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
@@ -333,7 +333,7 @@
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="http://w3.org/Consortium/Patent-Policy-20040205/">W3C Patent Policy</a> (5 February 2004 Version). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://w3.org/Consortium/Patent-Policy-20040205/">W3C Patent Policy</a> (5 February 2004 Version). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
 
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
         </p>


### PR DESCRIPTION
In the template and README.

While at it, remove a few trailing spaces (see the diff of the PR ignoring those whitespace changes [by appending `?w=1` to the URL](https://github.com/w3c/charter-drafts/pull/136/files?w=1)).