### PR TITLE
add WICG specs table

### DIFF
--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -495,8 +495,10 @@
                 <a href="https://github.com/WICG/web-locks">Web Locks API</a>
               </td>
               <td>
-                An API that lets websites gain write access to the native file
-                system.
+                API that allows script to asynchronously acquire a lock over a
+                resource, hold it while work is performed, then release it.
+                While held, no other script in the origin can aquire a lock
+                over the same resource.
               </td>
             </tr>
             <tr>

--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -495,9 +495,9 @@
                 <a href="https://github.com/WICG/web-locks">Web Locks API</a>
               </td>
               <td>
-                API that allows script to asynchronously acquire a lock over a
-                resource, hold it while work is performed, then release it.
-                While held, no other script in the origin can aquire a lock
+                An API that allows script to asynchronously acquire a lock over
+                a resource, hold it while work is performed, then release it.
+                While held, no other script in the origin can acquire a lock
                 over the same resource.
               </td>
             </tr>

--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -544,16 +544,6 @@
                 without showing a more heavyweight notification.
               </td>
             </tr>
-            <tr>
-              <td>
-                <a href="https://github.com/WICG/page-lifecycle">Page
-                Lifecycle</a>
-              </td>
-              <td>
-                An API that supports browsers' ability to manage lifecycle of
-                web pages.
-              </td>
-            </tr>
           </table>
         </section>
         <section id="ig-other-deliverables">

--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -449,8 +449,8 @@
             WICG specifications
           </h3>
           <p>
-            The following specifications are candidates specifications for
-            adoption by the working group.
+            Depending on the WICG progress, the Group may also produce W3C
+            Recommendations for the following documents: 
           </p>
           <table>
             <tr>

--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -444,6 +444,116 @@
             </tr>
           </table>
         </section>
+        <section>
+          <h3>
+            WICG specifications
+          </h3>
+          <p>
+            The following specifications are candidates specifications for
+            adoption by the working group.
+          </p>
+          <table>
+            <tr>
+              <th>
+                Specification
+              </th>
+              <th>
+                Description
+              </th>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/w3c/keyboard-lock">Keyboard
+                Lock</a>
+              </td>
+              <td>
+                An API that allows websites to capture and use reserved keys
+                and keyboard shortcuts.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://wicg.github.io/keyboard-map/">Keyboard Map</a>
+              </td>
+              <td>
+                An API that allows websites to convert from a given code value
+                to a valid key value that can be shown to the user to identify
+                the given key.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://wicg.github.io/cookie-store/">Cookie Store</a>
+              </td>
+              <td>
+                An asynchronous Javascript cookies API for documents and
+                workers.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/WICG/web-locks">Web Locks API</a>
+              </td>
+              <td>
+                An API that lets websites gain write access to the native file
+                system.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/WICG/writable-files">Writable
+                Files</a>
+              </td>
+              <td>
+                An API that lets websites gain write access to the native file
+                system.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://wicg.github.io/web-share/">Web Share API</a>
+              </td>
+              <td>
+                An API for sharing text, links and other content to an
+                arbitrary destination of the user's choice.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://wicg.github.io/web-share-target/">Web Share
+                Target</a>
+              </td>
+              <td>
+                An API that allows websites to declare themselves as web share
+                targets, which can receive shared content from either the Web
+                Share API, or system events (e.g., shares from native apps).
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://wicg.github.io/badging/">Badging</a>
+              </td>
+              <td>
+                An API allowing web applications to set an application-wide
+                badge, shown in an operating-system-specific place associated
+                with the application (such as the shelf or home screen), for
+                the purpose of notifying the user when the state of the
+                application has changed (e.g., when new messages have arrived),
+                without showing a more heavyweight notification.
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://github.com/WICG/page-lifecycle">Page
+                Lifecycle</a>
+              </td>
+              <td>
+                An API that supports browsers' ability to manage lifecycle of
+                web pages.
+              </td>
+            </tr>
+          </table>
+        </section>
         <section id="ig-other-deliverables">
           <h3>
             Other Deliverables

--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -503,16 +503,6 @@
             </tr>
             <tr>
               <td>
-                <a href="https://github.com/WICG/writable-files">Writable
-                Files</a>
-              </td>
-              <td>
-                An API that lets websites gain write access to the native file
-                system.
-              </td>
-            </tr>
-            <tr>
-              <td>
                 <a href="https://wicg.github.io/web-share/">Web Share API</a>
               </td>
               <td>


### PR DESCRIPTION
@plehegar, could you provide us some guidance with regards to these? See my email about the updated scope and if we should list these explicitly.  

We should get some kind of public signal that implementers and the community are interested in: 

 * [ ] https://github.com/w3c/keyboard-lock/issues/48
 * [ ] https://github.com/WICG/keyboard-map/issues/23
 * [x] https://github.com/WICG/cookie-store/issues/96 Mozilla support + Google implements.
 * [ ] https://github.com/WICG/web-locks/issues/55
 * [x] https://github.com/WICG/web-share/issues/83  Apple implement + Google implements.
 * [x] https://github.com/WICG/web-share-target/issues/73  Mozilla supports + Google implements.
 * [x] https://github.com/WICG/badging/issues/15 - Mozilla supports + Google implements.

The following were rejected:
 * https://github.com/WICG/page-lifecycle/issues/28  - will go into HTML
 * https://github.com/WICG/writable-files/issues/32 - needs more work.  