### PR TITLE
Added ARIA coordination, and encourage reviews

### DIFF
--- a/webapps-2019.html
+++ b/webapps-2019.html
@@ -187,11 +187,10 @@
           </li>
         </ul>
         <p>
-          For <a href="#background">historical reasons</a>, the working group
-          maintains a specification for mapping HTML elements and attributes to
+          The working group also maintains a specification for mapping HTML elements and attributes to
           platform accessibility APIs, and a separate specification that
           defines author conformance requirements for setting ARIA attributes.
-          However, the Working Group does not expect to add any other
+          The Working Group does not expect to add any other
           specifications relating to this matter.
         </p>
         <p>
@@ -581,12 +580,17 @@
           </dd>
         </dl>
         <p>
+          The WebApps Group will also seek review from the <a href="https://www.w3.org/WAI/ARIA/">Accessible Rich Internet
+          Applications (ARIA) Working Group</a> to coordinate on the ARIA attributes on HTML elements, and their mappings
+          to platform accessibility APIs.
+        </p>
+        <p>
           Invitations for review will be issued for each major transition of a
           specification, including <a href=
           "https://www.w3.org/Consortium/Process/#RecsWD">First Public Working
           Draft</a>, and at least 3 months before <a href=
           "https://www.w3.org/Consortium/Process/#RecsCR">Candidate
-          Recommendation</a>.
+          Recommendation</a>, and should be issued when major changes occur in a specification.
         </p>
         <div id="w3c-coordination">
           <h3>


### PR DESCRIPTION
Since the Group is working on ARIA, we need to coordinate with the ARIA working group. Removed "For historical reasons" in scope since it didn't lead anywhere and didn't seem to bring much anyway.
It would be good to seek out a new review from ARIA since it hasn't been done for sometimes.

Re-added [reviews] "should be issued when major changes occur in a specification." as well since it's good practice.

