### PR TITLE
Add Media IG in the loop for media testing

### DIFF
--- a/browser-testing-tools.html
+++ b/browser-testing-tools.html
@@ -221,6 +221,7 @@
           <ul>
             <li><a href="/WebPlatform/WG/">Web Platform Working Group</a></li>
             <li><a href="/Style/CSS/">CSS Working Group</a></li>
+            <li><a href="/2011/webtv/">Media and Entertainment Interest Group</a></li>
             <li><a href="/WAI/APA/">Accessible Platform Architectures (APA) Working Group</a>
               (given that there is a possibility of relevant accessibility considerations in APIs for browser testing)</li>
           </ul>


### PR DESCRIPTION
We got a suggestion to make sure BTT puts the Media IG in the loop regarding testing of media.

@sideshowbarker  @AutomatedTester , any objection to add the Media IG in the list of coordination? It's not clear to me that WebDriver will extend the testing surface of media in the short future, so it may not have any actual implication.
