### PR TITLE
link and also inline the testing policy. Fixes #194

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -228,7 +228,16 @@
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>
-	  <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+    <p>To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>:</p>
+    <section id="test-as-you-commit">
+        <ul>
+          <li><p>All normative spec changes are generally expected to have a corresponding pull request in <a href="https://github.com/web-platform-tests/wpt">web-platform-tests</a>, either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the proposed update.</p></li>
+
+          <li><p>Typically, both pull requests (spec updates and tests) will be merged at the same time. If a pull request for the specification is approved but the other needs more work, add the '<a href="https://w3c.github.io/spec-labels.html" rel="nofollow">needs tests</a>' label or, in web-platform-tests, the '<a href="https://github.com/web-platform-tests/wpt/issues?utf8=%E2%9C%93&amp;q=label%3Astatus%3Aneeds-spec-decision%20">status:needs-spec-decision</a>' label. Note that a test change that contradicts the specification should not be merged before the corresponding specification change.</p></li>
+
+          <li><p>If testing is not practical due to web-platforms-tests limitations, please explain why and if appropriate file an issue with the '<a href="https://github.com/web-platform-tests/wpt/issues?utf8=%E2%9C%93&amp;q=label%3Atype%3Auntestable%20">type:untestable</a>' label to follow up later.</p></li>
+        </ul>
+      </section>
 	</section>
 
       <section id="coordination">


### PR DESCRIPTION
Links to the w3c-hosted testing policy and also (as per Ralph's request) inlines the main points of that policy.
Therefore WGs can customize the inlined portion, if they wish.