### PR TITLE
[WebAssembly] Use CG proposal repo instead of W3 pubstatus page

### DIFF
--- a/wasm-2019.html
+++ b/wasm-2019.html
@@ -200,7 +200,7 @@
           Deliverables
         </h2>
 
-        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/[groupname]/PubStatus">group publication status page</a>.</p>
+        <p>More detailed proposals, milestones and updated publication schedules are available on the <a href="https://github.com/WebAssembly/proposals/blob/master/README.md">community group proposals repo</a>.</p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 

--- a/wasm-2019.html
+++ b/wasm-2019.html
@@ -200,7 +200,9 @@
           Deliverables
         </h2>
 
-        <p>More detailed proposals, milestones and updated publication schedules are available on the <a href="https://github.com/WebAssembly/proposals/blob/master/README.md">community group proposals repo</a>.</p>
+        <p> .   Revisions to the WebAssembly Recommendation will be proposed periodically, capturing changes that have been incrementally adopted by the Working Group.
+		Each successive version will incrementally incorporate improvements to support more machine level operations, increase performance, or to better inter-operate with embedding platforms.
+		More detailed proposals, milestones and updated publication schedules are available on the <a href="https://github.com/WebAssembly/proposals/blob/master/README.md">community group proposals repo</a>.</p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 


### PR DESCRIPTION
For up-to-date information on milestones, proposals, and publication schedules,
the Community Group proposal repo has accurate and up-to-date information, whereas the W3C wiki is currently a dead link and is likely to become out-of-date.