### PR TITLE
[WebAssembly] Alternative to linking to the CG proposal repo

### DIFF
--- a/wasm-2019.html
+++ b/wasm-2019.html
@@ -200,7 +200,19 @@
           Deliverables
         </h2>
 
-        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/[groupname]/PubStatus">group publication status page</a>.</p>
+        <p>
+		Revisions to the WebAssembly Recommendation will be proposed periodically, capturing changes that have been incrementally adopted by the Working Group.
+		Each successive version will incrementally incorporate improvements to support more machine level operations, increase performance, or to better inter-operate with embedding platforms, including features such as:
+		<ul>
+			<li>Multiple return values</li>
+			<li>Multiple memories + tables</li>
+			<li>Threads + shared memory</li>
+			<li>SIMD</li>
+			<li>Reference types</li>
+			<li>Exception handling</li>
+			<li>Garbage collected object support</li>
+			<li>Interface types</li>
+	</p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 


### PR DESCRIPTION
This would be an alternative to #250, in case there's some reason we shouldn't link to an external source or want an explicit list.