### PR TITLE
Constrain body text for readability

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -9,10 +9,14 @@
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
     <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
       ul#navbar {
         font-size: small;
       }
-
 
       dt.spec {
         font-weight: bold;
@@ -42,7 +46,6 @@
       footer {
         font-size: small;
       }
-
     </style>
   </head>
   <body>


### PR DESCRIPTION
I'm proposing to constrain text within `<main>` for readability. Uses same styles as https://w3c.github.io/cg-charter/CGCharter.html