### PR TITLE
Prepare for the new Patent Policy

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -356,6 +356,13 @@
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
         </p>
 
+        <p>
+          If the Director approves the proposed <a href='https://www.w3.org/2020/06/DRAFT-PP2020.html'>W3C Patent
+            Policy (23 June 2020)</a>, without making subtantives changes following the <a
+            href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0002.html'>Advisory Committee
+            review</a>, this charter will be updated in place to use the new Patent Policy.
+        </p>
+
         <h2>Patent Disclosures </h2>
         <p>The Interest Group provides an opportunity to
           share perspectives on the topic addressed by this charter. W3C reminds

--- a/charter-template.html
+++ b/charter-template.html
@@ -358,9 +358,9 @@
 
         <p>
           If the Director approves the proposed <a href='https://www.w3.org/2020/06/DRAFT-PP2020.html'>W3C Patent
-            Policy (23 June 2020)</a>, without making subtantives changes following the <a
+            Policy (Draft dated 23 June 2020)</a>, without making subtantives changes following the <a
             href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0002.html'>Advisory Committee
-            review</a>, this charter will be updated in place to use the new Patent Policy.
+            review</a>, this charter will be updated in place to use the updated Patent Policy.
         </p>
 
         <h2>Patent Disclosures </h2>


### PR DESCRIPTION
This implements the suggestion to have new proposed charters from now on it to be switched to the new Patent Policy when becoming effective.

@wseltzer , you need to sign off on this (or could be discussed on July 10 if you prefer)

@wseltzer and @caribouW3 , if the Director do charters such Group before PP2020 gets adopted, should/can we add a note in the joint IPP form?
