### PR TITLE
[decentralized] Drop "web" from proposed group title

### DIFF
--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -56,6 +56,8 @@
         <li><a href="#participation">Participation</a></li>
         <li><a href="#communication">Communication</a></li>
         <li><a href="#decisions">Decision Policy</a></li>
+        <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
+        <li><a href="#patentpolicy">Patent Policy</a></li>
         <li><a href="#patentpolicy">Patent Disclosures</a></li>
         <li><a href="#licensing">Licensing</a></li>
         <li><a href="#about">About this Charter</a></li>
@@ -68,7 +70,7 @@
 
   <main>
     <h1 id="title">Decentralized Web Interest Group Charter</h1>
-    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve guidelines
+    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve recommendations
       to further the W3C’s One Web purpose by identifying, balancing and mitigating the unintended impacts of proposals
       early in the process, encouraging uniform change, and promoting
       <a href="https://open-stand.org/about-us/principles/">OpenStand</a> principles.</p>

--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -171,6 +171,7 @@
         <h3 id="out-of-scope">Out of Scope</h3>
         <p>The following features are out of scope, and will not be addressed by this Interest group.</p>
         <ul class="out-of-scope">
+          <li>DIG does not engage in horizontal review.</li>
           <li>DIG does not incubate standards or specifications work to avoid overlap with other incubation, interest
             and working groups.</li>
           <li>DIG does not define policy decisions related to what are “good” or “bad” changes, but instead provides

--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -189,6 +189,7 @@
         Accountability that contribute to the decentralized, stable One Web.</p>
       <p>DIG will maintain an introductory document to help proposal authors better understand foreseeable impacts of
         their work by summarising and linking to external documents and bodies of work related to relevant topics.</p>
+      <p>DIG will produce terminology translation guides for use by a) specification authors, b) the legally minded and c) people who use the web.</p>
       <p>DIG may publish other documents consistent with the above scope.</p>
       <p>Note: drafts of <a href="https://github.com/w3c/web-advertising/blob/master/success-criteria.md">success
           criteria</a> and the <a

--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -74,8 +74,7 @@
       early in the process, encouraging uniform change, and promoting
       <a href="https://open-stand.org/about-us/principles/">OpenStand</a> principles.</p>
     <div class="noprint">
-      <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the Decentralized Web Interest
-          Group.</a></p>
+      <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the Decentralized Interest Group.</a></p>
     </div>
 
     <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available

--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
 
-  <title>DRAFT Decentralized Web Interest Group Charter</title>
+  <title>DRAFT Decentralized Interest Group Charter</title>
 
   <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
   <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -67,9 +67,9 @@
   </header>
 
   <main>
-    <h1 id="title">DRAFT Decentralized Web Interest Group Charter</h1>
+    <h1 id="title">DRAFT Decentralized Interest Group Charter</h1>
     <p>
-    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve guidelines
+    <p class="mission">The <strong>mission</strong> of the Decentralized Interest Group is to evolve guidelines
       to further the W3C’s One Web purpose by identifying, balancing and mitigating the unintended impacts of proposals
       early in the process, encouraging uniform change, and promoting
       <a href="https://open-stand.org/about-us/principles/">OpenStand</a> principles.</p>
@@ -155,15 +155,15 @@
         individual or group to foresee.</p>
       <p>Where changes to web standards impact stakeholder groups that are underrepresented within the W3C these
         unintended consequences are often missed or discovered late in the process.</p>
-      <p>To address this challenge, DWIG develops guidelines to assist specification authors in identifying, balancing
+      <p>To address this challenge, DIG develops guidelines to assist specification authors in identifying, balancing
         and mitigating unintended consequences early in the specification development process. This input enables
         proposal authors to address those concerns that might otherwise be raised later as issues or objections, thus
         reducing the overall time from proposal to consensus.</p>
-      <p>DWIG may provide input on request to other W3C groups developing web standards to help identify early impacts
+      <p>DIG may provide input on request to other W3C groups developing web standards to help identify early impacts
         on the broader web community beyond the focus of their specification.</p>
-      <p>DWIG provides short commentary on matters presented to the AC for consideration where there is a risk the
+      <p>DIG provides short commentary on matters presented to the AC for consideration where there is a risk the
         matter will impact on the stability or decentralized nature of the web.</p>
-      <p>DWIG aims to include members with diverse skillsets and backgrounds to ensure its work benefits from
+      <p>DIG aims to include members with diverse skillsets and backgrounds to ensure its work benefits from
         disciplines such as business, economics, law, policy and product, whose broad experience are often
         underrepresented in other specific interest, incubation and working groups.</p>
       <p>The web must be a stable and sustainable place for all to operate if the W3C are to continue to advance its
@@ -172,9 +172,9 @@
         <h3 id="out-of-scope">Out of Scope</h3>
         <p>The following features are out of scope, and will not be addressed by this Interest group.</p>
         <ul class="out-of-scope">
-          <li>DWIG does not incubate standards or specifications work to avoid overlap with other incubation, interest
+          <li>DIG does not incubate standards or specifications work to avoid overlap with other incubation, interest
             and working groups.</li>
-          <li>DWIG does not define policy decisions related to what are “good” or “bad” changes, but instead provides
+          <li>DIG does not define policy decisions related to what are “good” or “bad” changes, but instead provides
             guidance to proposal authors and reviewers to ensure they consider potential impacts to stability and
             decentralized nature of the web beyond the scope of their group.</li>
         </ul>
@@ -185,11 +185,11 @@
       <h2>
         Deliverables
       </h2>
-      <p>DWIG maintains a Self-Review Questionnaire for concerns of Decentralization, Choice, Auditability, and
+      <p>DIG maintains a Self-Review Questionnaire for concerns of Decentralization, Choice, Auditability, and
         Accountability that contribute to the decentralized, stable One Web.</p>
-      <p>DWIG will maintain an introductory document to help proposal authors better understand foreseeable impacts of
+      <p>DIG will maintain an introductory document to help proposal authors better understand foreseeable impacts of
         their work by summarising and linking to external documents and bodies of work related to relevant topics.</p>
-      <p>DWIG may publish other documents consistent with the above scope.</p>
+      <p>DIG may publish other documents consistent with the above scope.</p>
       <p>Note: drafts of <a href="https://github.com/w3c/web-advertising/blob/master/success-criteria.md">success
           criteria</a> and the <a
           href="https://github.com/w3c/web-advertising/blob/master/interoperability-choice-accessibility-accountability-questionairre.md">questionnaire</a>
@@ -264,7 +264,7 @@
       <h2 id="participation">
         Participation
       </h2>
-      <p>Participation in DWIG is open to the public. Participants who do not represent a W3C Member should join as
+      <p>Participation in DIG is open to the public. Participants who do not represent a W3C Member should join as
         Invited Experts. <a href="https://www.w3.org/2004/08/invexp.html">Invited Experts</a> in this group are not
         granted access to Member-only information.</p>
       <p>Anyone may subscribe to the group's public mailing list and engage in discussion. Those who intend to
@@ -290,10 +290,10 @@
       </p>
       <p>
         Information about the group (including details about deliverables, issues, actions, status, participants, and
-        meetings) will be available from the Decentralized Web Interest Group home page.</a>
+        meetings) will be available from the Decentralized Interest Group home page.</a>
       </p>
       <p>
-        Most Decentralized Web Interest Group teleconferences will focus on discussion of particular specifications, and
+        Most Decentralized Interest Group teleconferences will focus on discussion of particular specifications, and
         will be conducted on an as-needed basis.
       </p>
       <p>

--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -56,8 +56,6 @@
         <li><a href="#participation">Participation</a></li>
         <li><a href="#communication">Communication</a></li>
         <li><a href="#decisions">Decision Policy</a></li>
-        <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
-        <li><a href="#patentpolicy">Patent Policy</a></li>
         <li><a href="#patentpolicy">Patent Disclosures</a></li>
         <li><a href="#licensing">Licensing</a></li>
         <li><a href="#about">About this Charter</a></li>
@@ -71,7 +69,7 @@
   <main>
     <h1 id="title">DRAFT Decentralized Web Interest Group Charter</h1>
     <p>
-    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve recommendations
+    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve guidelines
       to further the W3C’s One Web purpose by identifying, balancing and mitigating the unintended impacts of proposals
       early in the process, encouraging uniform change, and promoting
       <a href="https://open-stand.org/about-us/principles/">OpenStand</a> principles.</p>

--- a/decentralized-charter.html
+++ b/decentralized-charter.html
@@ -56,8 +56,6 @@
         <li><a href="#participation">Participation</a></li>
         <li><a href="#communication">Communication</a></li>
         <li><a href="#decisions">Decision Policy</a></li>
-        <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
-        <li><a href="#patentpolicy">Patent Policy</a></li>
         <li><a href="#patentpolicy">Patent Disclosures</a></li>
         <li><a href="#licensing">Licensing</a></li>
         <li><a href="#about">About this Charter</a></li>
@@ -70,7 +68,7 @@
 
   <main>
     <h1 id="title">Decentralized Web Interest Group Charter</h1>
-    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve recommendations
+    <p class="mission">The <strong>mission</strong> of the Decentralized Web Interest Group is to evolve guidelines
       to further the W3C’s One Web purpose by identifying, balancing and mitigating the unintended impacts of proposals
       early in the process, encouraging uniform change, and promoting
       <a href="https://open-stand.org/about-us/principles/">OpenStand</a> principles.</p>


### PR DESCRIPTION
Following issue review remove the word "web" from the proposed group title. New name is Decentralized Interest Group of DIG.