### PR TITLE
MathML Working Group Draft Charter

### DIFF
--- a/math-2020.html
+++ b/math-2020.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title>MathML Working Group Charter</title>
+    <title>Math Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -72,13 +72,13 @@
 
 
     <main>
-      <h1 id="title">PROPOSED MathML Working Group Charter</h1>
+      <h1 id="title">PROPOSED Math Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">MathML Working Group</a> is to promote the inclusion of mathematics on the Web so that it is a first class citizen of the web that displays well, is accessibility and is searchable.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">Math Working Group</a> is to promote the inclusion of mathematics on the Web so that it is a first class citizen of the web that displays well, is accessible, and is searchable.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the MathML Working Group.</a></p>
+        <p class="join todo"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the Math Working Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -166,7 +166,7 @@ and has had wide adoption by the tools used to generate and consume math, browse
 
 
 <p>
-The MathML Refresh Community Group (CG) was formed to revise MathML to address perceived deficiencies in the spec. The MathML Working Group will advance, refine, and clarify the work begun by the MathML Community Group and ensure MathML&rsquo;s relevance continues to evolve, grow and improve. In particular, there are three goals the group hopes to advance:
+The MathML Refresh Community Group (CG) was formed to revise MathML to address perceived deficiencies in the spec. The Math Working Group will advance, refine, and clarify the work begun by the MathML Community Group and ensure MathML&rsquo;s relevance continues to evolve, grow and improve. In particular, there are three goals the group hopes to advance:
 </p>
 <ul>
 <li>
@@ -191,7 +191,7 @@ The Working Group will take up new work, such as problems the CG identified as r
 The Working Group will also overhaul MathML 3 building upon these fundamentals and experience with needs for accessibility and with many years of practical experience and use (or lack thereof), to create a path forward as MathML 4.
 </p>
 <p>
-The scope of the MathML Working Group includes the following:
+The scope of the Math Working Group includes the following:
 </p>
 <ul>
 <li>
@@ -261,7 +261,7 @@ Adding new elements for use exclusively outside the platform
 
 
               <p class="draft-status"><b>Draft state:</b>  <a href="https://mathml-refresh.github.io/mathml-core/">Final Community Group Editor's Draft</a></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+              <p class="milestone"><b>Expected completion:</b> Q1 2021</p>
     </dd>
 
 
@@ -275,18 +275,19 @@ accessibility mappings of elements and attributes.
 
 
               <p class="draft-status"><b>Draft state:</b> No draft </p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
   </dd>
 
 
             <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
             <dd>
-<p>This specification will attempt to overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. 
+<p>This specification will overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. 
 It will add attributes that allow specification of mathematical intent on Presentation MathML elements to enhance accessibility and searchability of math.</p>
 
 
               <p class="draft-status"><b>Draft state:</b> <a href="https://mathml-refresh.github.io/mathml/">Community Group's Initial Revision of MathML 3</a></p>
               <p class="milestone"><b>Expected completion:</b> Q4 2022</p>
+
+              <p><b>Adopt Draft:</b> <a href="https://www.w3.org/TR/MathML3/">Mathematical Markup Language (MathML) Version 3.0 2nd Edition</a></p>
     </dd>
 
 	  </dl>
@@ -305,7 +306,8 @@ It will add attributes that allow specification of mathematical intent on Presen
 <li>MathML Accessibility Techniques</li>
 <li>Guides on annotating Presentation MathML for accessibility and search</li>
 <li>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</li>
-<li>Sample code that employs heuristics to adds accessibility/searchability annotations to Presentation MathML that lacks those annotations.</li>
+<li>Sample code that converts default "intent" values to explict "intent" values in Presentation MathML.</li>
+<li>At least one TeX-to-MathML converter that incorporates accessibility/searchability annotations in its MathML output.
 <li>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</li>
 <li>Sample code for conversion of annotated Presentation MathML to an external form such as speech and/or Content MathML</li>
 </ul>
@@ -315,14 +317,21 @@ It will add attributes that allow specification of mathematical intent on Presen
         <section id="timeline">
           <h3>Timeline</h3>
 	  <p>These dates are not meant as deadlines; work may need to continue after these dates to ensure the quality of the deliverables.</p>
-            <p class="todo">Put here a timeline view of all deliverables.</p>
-            <ul class="todo">
-              <li>Month YYYY: First teleconference</li>
-              <li>Month YYYY: First face-to-face meeting</li>
-              <li>Month YYYY: Requirements and Use Cases for FooML</li>
-              <li>Month YYYY: FPWD for FooML</li>
-              <li>Month YYYY: Requirements and Use Cases for BarML</li>
-              <li>Month YYYY: FPWD FooML Primer</li>
+            <ul>
+              <li>January 2021: First teleconference</li>
+              <li>October 2021: First face-to-face meeting (TPAC)</li>
+              <li>February 2021: FPWD, MathML Core Level 1 </li>
+              <li>May 2021: FPWD, MathML 4 </li>
+              <li>October 2021: MathML Core Test Suites</li>
+              <li>October 2021: Implementation Report</li>
+              <li>October 2021: Candidate Recommendation, MathML Core Level 1 </li>
+              <li>December 2021: Sample code that adds annotations making defaults explicit</li>
+              <li>January 2022: Code that converts Content MathML to annotated Presentation MathML</li>
+              <li>February 2022: FPWD, MathML Core Level 2</li>
+              <li>April 2022: Sample code that uses annotated Presentation MathML to create Speech and/or Content MathML</li>
+              <li>May 2022: Prototype TeX-to-annotated MathML implementation</li>
+              <li>September 2022: Living catalog established for extended Presentation annotations </li>
+              <li>October 2022: Candidate Recommendation, MathML 4</li>
             </ul>
         </section>
       </section>
@@ -330,7 +339,7 @@ It will add attributes that allow specification of mathematical intent on Presen
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
 
-<p>The MathML Working Group&rsquo;s work is considered a success if:</p>
+<p>The Math Working Group&rsquo;s work is considered a success if:</p>
 <ul>
 <li>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used</li>
 <li>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core features aimed at improving accessibility by authoring tools/MathML converters.</li>
@@ -357,13 +366,11 @@ It will add attributes that allow specification of mathematical intent on Presen
 
         <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
-      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
-
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
 	    <dt><a href="https://www.w3.org/Style/CSS/">CSS Working Group</a></dt>
-	    <dd>The MathML Working Group will contribute to and coordinate work with the CSS Working Group related to aligning the development and testing of new and existing CSS functionalities that are of interest to the MathML community. The group will designate liaisons to work with the CSS Working Group on issues as needed. Liaisons will ideally be participants of both groups.</dd>
+	    <dd>The Math Working Group will contribute to and coordinate work with the CSS Working Group related to aligning the development and testing of new and existing CSS functionalities that are of interest to the MathML community. The group will designate liaisons to work with the CSS Working Group on issues as needed. Liaisons will ideally be participants of both groups.</dd>
 	    <dt><a href="https://www.w3.org/community/wicg/">Web Incubator Community Group (WICG)</a></dt>
 	    <dd>The Web Platform Incubator Community Group
 	      (<a href="https://www.w3.org/community/wicg/">WICG</a>)
@@ -395,7 +402,7 @@ and continue to improve the accessibility of that which is part of MathML.
 <a href="https://www.w3.org/TR/SVG11/">SVG</a>.
 While largely non-overlapping technically, the two share similar origin stories and are both unique in their integration with the HTML Parser specification and integration as
 <a href="https://html.spec.whatwg.org/multipage/dom.html%23embedded-content-category">embedded content</a>.
-As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in proving common developer experiences and expectations. The MathML Working Group will make attempts to coordinate furthering these efforts together with the SVG Working Group (and the
+As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in proving common developer experiences and expectations. The Math Working Group will make attempts to coordinate furthering these efforts together with the SVG Working Group (and the
 <a href="https://www.w3.org/community/svgcg/">SVG CG</a>).
 	    </dd>
 
@@ -403,9 +410,6 @@ As such they have many similar challenges and efforts to align with the larger W
 	    <dd>Chemical Formulas make use of mathematical notations. The Chem CG is concerned about the accessibility challenges of using math notations and having them spoken and brailled appropriately. The Math CG has worked with the Chem CG to ensure appropriate access to chemical formulas and the MathML WG will continue this effort.</dd>
           </dl>
 
-          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
-          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
-            Instead, put it in the scope section.</p>
         </section>
 
         <section>
@@ -455,10 +459,10 @@ This may have an influence on the future evolution of MathML. Efforts to align M
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/Math">MathML Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/Math">Math Working Group home page.</a>
         </p>
         <p>
-          Most MathML Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most Math Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
           This group primarily conducts its technical work  on <a id="public-github" href="https://github.com/mathml-refresh/mathml/issues">GitHub issues</a>.
@@ -569,7 +573,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
               </tr>
               <tr>
                 <th>
-                  <a class="todo" href="">Initial Charter</a>
+                  <a>Initial Charter</a>
                 </th>
                 <td>
                   4 January, 2021
@@ -624,8 +628,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
       </address>
 
       <p class="copyright">
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
-        <i class="todo">[yyyy]</i>
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©2020
         <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
         (
         <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,

--- a/math-2020.html
+++ b/math-2020.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title><i>MathML</i> Working Group Charter</title>
+    <title>MathML Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">

--- a/math-2020.html
+++ b/math-2020.html
@@ -134,7 +134,7 @@
               Meeting Schedule
             </th>
             <td>
-              <strong>Teleconferences:</strong> two 1 hour calls working on different aspects of MathML to be held weekly as needed to resolve issues
+              <strong>Teleconferences:</strong> two 1-hour calls working on different aspects of MathML to be held weekly to resolve issues as needed. 
               <br>
               <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than one additional meeting per year.
             </td>
@@ -152,43 +152,46 @@
 	  <h3>Background and Motivation</h3>
 <p>
 <a href="https://www.w3.org/Math/">MathML </a>
-is a markup language for encoding and sharing mathematics.The need for mathematical rendering on the web
-was evident from the
+is a markup language for encoding and communicating mathematics.The need for 
+mathematical rendering on the web was evident from the
 <a href="https://www.w3.org/MarkUp/HTMLPlus/htmlplus_45.html">earliest days of the Web at CERN</a>,
-and MathML was among the first specifications taken up and developed by the W3C in the mid/late-1990&#39;s XML/XHTML era. It received much attention and has created a vibrant ecosystem of implementations and integration outside of web browsers, and it advanced on the Web itself becoming integrated, along with SVG into the HTML Parser and the HTML Specification in the mid 2000s. Since then, much has happened. While MathML has much
-success with making math accessible
-and has had wide adoption by the tools used to generate and consume math, browser adoption is not universal. The MathML 3 specification does not match some current Web realities; it does not contain precise enough requirements for interoperability within the Web Platform; and some features are either incompatible with or subsumed by new features added to the Web Platform outside MathML.
+and MathML was among the first specifications taken up and developed by the W3C in the mid to late 1990&#39;s XML/XHTML era. It received much attention and has created a vibrant ecosystem of implementations and integration outside of web browsers. It advanced on the Web itself becoming integrated, along with SVG, into the HTML Parser and the HTML Specification in the mid 2000&#39;s. Since then, much has happened. While MathML 
+has much success with making math accessible
+and has had wide adoption in the tools used to generate and consume math, browser adoption is not universal. The MathML 3 specification does not match some current Web realities; 
+it does not contain precise enough requirements for interoperability with the now changed Web Platform; indeed, some features are either incompatible with, or subsumed by, new features added to the Web Platform outside MathML.
 </p>
 </section>
 
       <section id="scope-inscope" class="scope">
         <h3>Scope</h3>
 
-
 <p>
-The MathML Refresh Community Group (CG) was formed to revise MathML to address perceived deficiencies in the spec. The Math Working Group will advance, refine, and clarify the work begun by the MathML Community Group and ensure MathML&rsquo;s relevance continues to evolve, grow and improve. In particular, there are three goals the group hopes to advance:
+The MathML Refresh Community Group (CG) was formed to begin revision of MathML to address perceived difficulties in the MathML 3 spec. The Math Working Group will advance, refine, and clarify the work begun by the MathML Refresh Community Group and ensure MathML&rsquo;s relevance continues to evolve, grow and improve. In particular, there are three 
+goals the Math WG will work toward:
 </p>
 <ul>
 <li>
-Wide adoption by browsers of a core set of presentational elements so that authors can be assured that math will be displayed similarly in all browsers without having to rely on external libraries to do the display.
+Wide adoption by browsers of a core set of presentational elements so that authors can be assured that mathematics will be displayed similarly in all browsers, without having to rely on external libraries to do the display.
 </li>
 <li>
 Increased accessibility of Presentation MathML for both
-mathematics and chemical formulas by allowing a means 
-of specifying relevant mathematical intent in-place, as well as providing guidelines for interpreting Presentation MathML in the absence of other information.
+mathematics and chemical formulas achieved by allowing a means 
+of specifying relevant mathematical intent in-place, as well as by 
+providing guidelines for interpreting Presentation MathML in the 
+absence of additional information.
 </li>
 <li>
-Ensuring that mathematical formulations are searchable.
+Ensuring that mathematical formulations are better searchable.
 </li>
 </ul>
 <p>
-The Working Group will begin by providing a thorough review and refinement of MathML Core Level 1, a restricted form of MathML created by the MathML Community Group, which has done the initial hard work of largely aligning with features of the platform and precisely defining its rendering, including integration with CSS and basic DOM, providing tests and opening bugs.
+The Working Group will begin by providing a thorough review and refinement of MathML Core Level 1, a restricted form of MathML created by the MathML Refresh Community Group, which has done the initial hard work of largely aligning with features of the current Web platform and precisely defining MathML&#39;s rendering, including integration with current CSS and basic DOM, and providing tests and opening bugs.
 </p>
 <p>
-The Working Group will take up new work, such as problems the CG identified as requiring better solutions in order to move MathML in the Web Platform forward, in MathML Core Level 2.
+The Working Group will take up new work, such as problems the CG identified as requiring better solutions in order to move MathML in the Web Platform forward, in proposing a MathML Core Level 2.
 </p>
 <p>
-The Working Group will also overhaul MathML 3 building upon these fundamentals and experience with needs for accessibility and with many years of practical experience and use (or lack thereof), to create a path forward as MathML 4.
+The Working Group will also overhaul MathML 3 by building upon these fundamentals and experience with needs for accessibility, and on many years of practical experience and use (or lack thereof), to create a path forward to a MathML 4.
 </p>
 <p>
 The scope of the Math Working Group includes the following:
@@ -218,10 +221,10 @@ Integration of new and existing Web Platform technologies, including, but not li
 <li>CSS</li>
 </ul>
 </li>
-<li>Integration with tools above and beyond browsers</li>
-<li>Improvements to the MathML markup and processing model to enhance accessibility and searchability</li>
-<li>Identification of normative requirements needed to ensure accessibility</li>
-<li>Removing elements and attributes from MathML that have had minimal adoption</li>
+<li>Integration with tools above and beyond browsers.</li>
+<li>Improvements to the MathML markup and processing model to enhance accessibility and searchability.</li>
+<li>Identification of normative requirements needed to ensure accessibility.</li>
+<li>Removing elements and attributes from MathML that have had minimal adoption.</li>
 </ul>
 </section>
 <section id="section-out-of-scope">
@@ -229,7 +232,7 @@ Integration of new and existing Web Platform technologies, including, but not li
 
 <ul>
 <li>
-Adding new elements for use exclusively outside the platform
+Adding new elements for use exclusively outside the Web Platform
 </li>
 <li>Changes that would cause legacy MathML that has significant usage to stop working on the Web Platform or elsewhere.</li>
 <li>Changes to Content MathML. These will be considered at a later time after gaining experience and feedback from proposed additions to enhance accessibility and searchability in Presentation MathML.</li>
@@ -257,10 +260,10 @@ Adding new elements for use exclusively outside the platform
           <dl>
             <dt id="mathml-core1" class="spec"><a href="#">MathML Core Level 1</a></dt>
             <dd>
-<p>This specification provides an initial integration into the Web Platform with increased implementation details, focusing on a subset of MathML 3 which has had wide implementation and fits well with the platform. It details and relies on automated Web Platform tests to improve MathML interoperability. It provides the core layer of MathML support upon which MathML 4 can build, and authors can implement remaining features (by polyfills), or more generally extend MathML Core, using modern web technologies.</p>
+<p>This specification provides an initial integration into the Web Platform with increased implementation details, focusing on a subset of MathML 3 which has had wide implementation and fits well with the platform. It details and relies on automated Web Platform tests to improve MathML interoperability. It provides the core layer of MathML support upon which MathML 4 can build. Authors can implement remaining features, or more generally extend MathML Core, using modern web technologies (e.g., by polyfills).</p>
 
 
-              <p class="draft-status"><b>Draft state:</b>  <a href="https://mathml-refresh.github.io/mathml-core/">Final Community Group Editor's Draft</a></p>
+              <p class="draft-status"><b>Draft state:</b>  <a href="https://mathml-refresh.github.io/mathml-core/">Final Community Group Editors' Draft</a></p>
               <p class="milestone"><b>Expected completion:</b> Q1 2021</p>
     </dd>
 
@@ -269,9 +272,10 @@ Adding new elements for use exclusively outside the platform
 
             <dt id="mathml-core2" class="spec"><a href="#">MathML Core Level 2</a></dt>
             <dd>
-<p>This specification will address features left out of Level 1 due to time and implementation constraints. It will provide guidance on improving MathML within the evolving web platform and enhancing the descriptions of generally polyfilling or extending MathML, using technologies such as a shadow DOM, custom elements, CSS layout API or other Houdini APIs. It will also address questions such as linking and accessibility through suggested 
-accessibility mappings of elements and attributes.
+<p>This specification will address some features left out of Level 1 due to time and implementation constraints. It will provide guidance on improving MathML within the evolving Web Platform and enhancing the descriptions of generally polyfilling or extending MathML, using technologies such as a Shadow DOM, Custom Elements, the CSS Layout API or other Houdini APIs. It will also address questions such as linking and accessibility through suggested accessibility mappings of elements and attributes.
 </p>
+
+<p>The MathML Core specifications are intended to define only those parts of MathML that are, or will be, implemented by all major browser engines.</p>
 
 
               <p class="draft-status"><b>Draft state:</b> No draft </p>
@@ -280,8 +284,8 @@ accessibility mappings of elements and attributes.
 
             <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
             <dd>
-<p>This specification will overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. 
-It will allow specification of mathematical intent on Presentation MathML elements to enhance accessibility and searchability of math.</p>
+<p>This specification will overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, make obsolete, or drop features that are not used and likely will not be used. 
+It will add attributes that allow specification of mathematical intent on Presentation MathML elements to enhance accessibility and searchability of math.</p>
 
 
               <p class="draft-status"><b>Draft state:</b> <a href="https://mathml-refresh.github.io/mathml/">Community Group's Initial Revision of MathML 3</a></p>
@@ -302,10 +306,11 @@ It will allow specification of mathematical intent on Presentation MathML elemen
             Other non-normative documents may be created such as:
           </p>
 <ul>
-<li>Test suites and implementation reports for the specification</li>
-<li>MathML Accessibility Techniques</li>
-<li>Guides on annotating Presentation MathML for accessibility and search</li>
+<li>Test suites and implementation reports for the specification.</li>
+<li>MathML Accessibility Technique Notes.</li>
+<li>Guides on annotating Presentation MathML for accessibility and search.</li>
 <li>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</li>
+<li>Sample code that converts default "intent" values to explicit "intent" values in Presentation MathML.</li>
 <li>At least one TeX-to-MathML converter that incorporates accessibility/searchability annotations in its MathML output.
 <li>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</li>
 <li>Sample code for conversion of annotated Presentation MathML to an external form such as speech and/or Content MathML</li>
@@ -340,12 +345,12 @@ It will allow specification of mathematical intent on Presentation MathML elemen
 
 <p>The Math Working Group&rsquo;s work is considered a success if:</p>
 <ul>
-<li>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used</li>
-<li>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core features aimed at improving accessibility by authoring tools/MathML converters.</li>
-<li>There is proven advancement and interest by implementers in MathML Core Level 2, exploring linking, better alignment with how the larger Web Platform evolves (Shadow DOM, Custom Elements, CSS)</li>
-<li>A MathML Full (MathML 4) specification, based on Core</li>
-<li>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
-<li>There are significant testing plans and all testable changes have tests.</li>
+<li>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used.</li>
+<li>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core features aimed at improving accessibility by authoring tools and MathML converters.</li>
+<li>There is proven advancement and interest by implementers in MathML Core Level 2, exploring linking, better alignment with how the larger Web Platform evolves (Shadow DOM, Custom Elements, CSS).</li>
+<li>A MathML Full (MathML 4) specification, based on Core.</li>
+<li>Each specification contains a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
+<li>There are significant testing plans, and all testable changes have tests.</li>
 <li>There is an AAM (Accessibility API Mapping) for MathML Core and there are considerations of the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</li>
 </ul>
 
@@ -375,17 +380,17 @@ It will allow specification of mathematical intent on Presentation MathML elemen
 	      (<a href="https://www.w3.org/community/wicg/">WICG</a>)
 	      provides a lightweight venue for proposing and
 	      discussing new web platform features, like new HTML
-	      features or Web Platform API-s. Also, new technical
+	      features or Web Platform APIs. Also, new technical
 	      features arising during the development of MathML may
 	      have relevance for the Web Platform in general, or ideas
 	      developing for the Web Platform in general might be
 	      developing in
 <a href="https://www.w3.org/community/wicg">WICG</a>
-which could be relevant to MathML. The MathML WG will make an effort to make sure these are explored further together within incubations in the Web Platform Incubator Community Group where appropriate.
+which could be relevant to MathML.  The MathML WG will make an effort to make sure these are explored further together within incubations in the Web Platform Incubator Community Group where appropriate.
 	    </dd>
 
 	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
-	    <dd>The APA WG provides horizontal review of potential accessibility issues in the architecture, including knowledge domains for STEM accessibility; as well as accessibility impact of a specification. The MathML WG will request reviews and coordinate, and may nominate liaisons to ensure that these groups are aligned and working in concert toward accessible mathematics.</dd>
+	    <dd>The APA WG provides horizontal review of potential accessibility issues in the architecture, including knowledge domains for STEM accessibility, as well as of the accessibility impact of a specification. The MathML WG will request reviews and coordinate, and may nominate liaisons to ensure that these groups are aligned and working in concert toward accessible mathematics.</dd>
 
 	    <dt><a href="https://www.w3.org/WAI/ARIA/">ARIA Working Group</a></dt>
 	    <dd>The ARIA Working Group is responsible for the development of ARIA and related Accessibility Mappings. The MathML WG will appoint a liaison and coordinate with the ARIA Working Group to provide the
@@ -394,19 +399,19 @@ and continue to improve the accessibility of that which is part of MathML.
 </dd>
 
 	    <dt><a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working Group</a></dt>
-	    <dd>The Publishing Working Group goal is to enable all publications to be first class citizens of the web. MathML is used by a large number of technical and textbook publishers in their workflows. The MathML WG will work with the PWG to ensure their needs are met with updates to the MathML recommendations.</dd>
+	    <dd>The Publishing Working Group's goal is to enable all publications to be first class citizens of the web. MathML is used by a large number of technical and textbook publishers in their workflows. The MathML WG will work with the PWG to ensure their needs are met with updates to the MathML recommendations.</dd>
 
 	    <dt><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></dt>
 	    <dd>The SVG Working Group is responsible for the development of
 <a href="https://www.w3.org/TR/SVG11/">SVG</a>.
-While largely non-overlapping technically, the two share similar origin stories and are both unique in their integration with the HTML Parser specification and integration as
+While largely non-overlapping technically, SVG and MathML share similar origin stories and are both special in their integration with the HTML Parser specification and integration as
 <a href="https://html.spec.whatwg.org/multipage/dom.html%23embedded-content-category">embedded content</a>.
-As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in proving common developer experiences and expectations. The Math Working Group will make attempts to coordinate furthering these efforts together with the SVG Working Group (and the
+As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in providing common developer experiences and expectations. The Math Working Group will attempt to coordinate furthering these efforts with the SVG Working Group (and the
 <a href="https://www.w3.org/community/svgcg/">SVG CG</a>).
 	    </dd>
 
-	    <dt><a href="https://www.w3.org/community/chem-web-pub/">Chemistry for the Web and Publishing Community Group</a></dt>
-	    <dd>Chemical Formulas make use of mathematical notations. The Chem CG is concerned about the accessibility challenges of using math notations and having them spoken and brailled appropriately. The Math CG has worked with the Chem CG to ensure appropriate access to chemical formulas and the MathML WG will continue this effort.</dd>
+	    <dt><a href="https://www.w3.org/community/chem-web-pub/">Chemistry for the Web and Publishing Community Group</a> (Chem CG)</dt>
+	    <dd>Chemical Formulas make use of mathematical notations. The Chem CG is concerned about the accessibility challenges of using math notations and having them spoken and brailed appropriately. The MathML Refresh CG has worked with the Chem CG to ensure appropriate access to chemical formulas and the Math WG will continue this effort.</dd>
           </dl>
 
         </section>
@@ -421,7 +426,7 @@ is responsible for the development of
 <a href="https://html.spec.whatwg.org/multipage/">HTML</a>
 and
 <a href="https://dom.spec.whatwg.org/">DOM</a>.
-This may have an influence on the future evolution of MathML. Efforts to align MathML Core with the Web Platform may lead to alignment requirements for these (new IDL, focusability, support for ideas like ShadowDOM, support for attributes, etc), in which case these should be explored further together with the WHATWG (and the
+This may have an influence on the future evolution of MathML. Efforts to align MathML Core with the Web Platform may lead to alignment requirements (issues might arise from a new IDL, focusability, support for ideas like Shadow DOM, support for attributes, etc.), in which case these should be explored further together with the WHATWG (and the
 <a href="https://www.w3.org/community/wicg/">WICG</a>).
 </dd>
           </dl>
@@ -454,7 +459,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted using documents that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
@@ -464,7 +469,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
           Most Math Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  on <a id="public-github" href="https://github.com/mathml-refresh/mathml/issues">GitHub issues</a>.
+          This group primarily conducts its technical work on <a id="public-github" href="https://github.com/mathml-refresh/mathml/issues">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
@@ -512,17 +517,17 @@ This may have an influence on the future evolution of MathML. Efforts to align M
 
         <p>
           If the Director approves the proposed <a href='https://www.w3.org/2020/06/DRAFT-PP2020.html'>W3C Patent
-            Policy (Draft dated 23 June 2020)</a>, without making subtantives changes following the <a
+            Policy (Draft dated 23 June 2020)</a>, without making substantive changes following the <a
             href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0002.html'>Advisory Committee
             review</a>, this charter will be updated in place to use the updated Patent Policy.
         </p>
 
         <h2>Patent Disclosures </h2>
-        <p>The Interest Group provides an opportunity to
+        <p>An Interest Group provides an opportunity to
           share perspectives on the topic addressed by this charter. W3C reminds
           Interest Group participants of their obligation to comply with patent
           disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
-            6</a> of the W3C Patent Policy. While the Interest Group does not
+            6</a> of the W3C Patent Policy. While an Interest Group does not
           produce Recommendation-track documents, when Interest Group
           participants review Recommendation-track specifications from Working
           Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
@@ -623,7 +628,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
 
     <footer>
       <address>
-        <i class="todo"><a href="mailto:">[team contact name]</a></i>
+        <i class="todo"><a href="mailto:bert@w3.org">[Bert Bos]</a></i>
       </address>
 
       <p class="copyright">

--- a/math-2020.html
+++ b/math-2020.html
@@ -1,0 +1,493 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+
+    <title><i class="todo">[name]</i> (Working|Interest) Group Charter</title>
+
+    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
+      ul#navbar {
+        font-size: small;
+      }
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+		  <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
+          <li><a href="#patentpolicy">Patent Policy</a></li>
+          <li><a href="#patentpolicy">Patent Disclosures</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
+      </p>
+    </header>
+
+
+    <main>
+      <h1 id="title"><i class="todo">PROPOSED [name]</i> (Working|Interest) Group Charter</h1>
+      <!-- delete PROPOSED after AC review completed -->
+
+      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
+      </div>
+
+         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
+
+    Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
+          </p>
+
+      <section id="details">
+        <table class="summary-table">
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+            </td>
+          </tr>
+          <tr id="CharterEnd">
+            <th>
+              End date
+            </th>
+            <td>
+              <i class="todo">[dd monthname yyyy]</i>
+            </td>
+          </tr>
+
+          <tr class="todo">
+            <th>Charter extension</th>
+            <td>See <a href="#history">Change History</a>.
+            </td>
+          </tr>
+
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              <i class="todo">[chair name] (affiliation)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
+              <br>
+              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+            </td>
+          </tr>
+        </table>
+
+        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
+      </section>
+
+
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+        <p><i class="todo">Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
+
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+
+            <ul class="out-of-scope">
+            </ul>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+
+        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/[groupname]/PubStatus">group publication status page</a>.</p>
+
+        <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+
+        <section id="normative">
+          <h3>
+            Normative Specifications
+          </h3>
+          <p>
+            The <i class="todo">(Working|Interest)</i> Group will deliver the following W3C normative specifications:
+          </p>
+          <dl>
+            <dt id="web-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
+            <dd>
+              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+   <dl><dt>
+    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
+      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
+      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
+    </dd>
+              </dl></dl>
+
+
+        </section>
+
+        <section id="ig-other-deliverables">
+          <h3>
+            Other Deliverables
+          </h3>
+          <p>
+            Other non-normative documents may be created such as:
+          </p>
+          <ul>
+            <li>Use case and requirement documents;</li>
+            <li>Test suite and implementation report for the specification;</li>
+            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+          </ul>
+        </section>
+
+        <section id="timeline">
+          <h3>Timeline</h3>
+            <p class="todo">Put here a timeline view of all deliverables.</p>
+            <ul class="todo">
+              <li>Month YYYY: First teleconference</li>
+              <li>Month YYYY: First face-to-face meeting</li>
+              <li>Month YYYY: Requirements and Use Cases for FooML</li>
+              <li>Month YYYY: FPWD for FooML</li>
+              <li>Month YYYY: Requirements and Use Cases for BarML</li>
+              <li>Month YYYY: FPWD FooML Primer</li>
+            </ul>
+        </section>
+      </section>
+
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
+	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
+	  <p>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
+		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
+		recommendations for maximising accessibility in implementations.</p>
+	  <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+	</section>
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all specifications, this <i class="todo">(Working|Interest)</i> Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
+          accessibility, internationalization, performance, privacy, and security with the relevant Working and
+          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
+          Invitation for review must be issued during each major standards-track document transition, including
+          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
+          <i class="todo">(Working|Interest)</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The <i class="todo">(Working|Interest)</i> Group is advised to seek a review at least 3 months before first entering
+          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
+          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+
+        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+
+      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+
+          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
+          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
+            Instead, put it in the scope section.</p>
+        </section>
+
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+          <dl>
+            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+        </section>
+      </section>
+
+
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, this <i class="todo">(Working|Interest)</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+        </p>
+        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
+      </section>
+
+
+
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this <i class="todo">(Working|Interest)</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
+        The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">[name]</i> (Working|Interest) Group home page.</a>
+        </p>
+        <p>
+          Most <i class="todo">[name]</i> (Working|Interest) Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
+          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          The public is invited to review, discuss and contribute to this work.
+        </p>
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
+      </section>
+
+
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus"> W3C Process Document (section 3.3</a>). Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+        <p>
+           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">(Working|Interest)</i> Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+        </p>
+        <p>
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 3.4, Votes)</a> and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+
+
+      <section id="patentpolicy">
+      <p><i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i></p>
+
+        <h2>
+          Patent Policy
+        </h2>
+        <p>
+          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 5 February 2004 updated 1 August 2017). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
+
+          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
+        </p>
+
+        <p>
+          If the Director approves the proposed <a href='https://www.w3.org/2020/06/DRAFT-PP2020.html'>W3C Patent
+            Policy (Draft dated 23 June 2020)</a>, without making subtantives changes following the <a
+            href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0002.html'>Advisory Committee
+            review</a>, this charter will be updated in place to use the updated Patent Policy.
+        </p>
+
+        <h2>Patent Disclosures </h2>
+        <p>The Interest Group provides an opportunity to
+          share perspectives on the topic addressed by this charter. W3C reminds
+          Interest Group participants of their obligation to comply with patent
+          disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
+            6</a> of the W3C Patent Policy. While the Interest Group does not
+          produce Recommendation-track documents, when Interest Group
+          participants review Recommendation-track specifications from Working
+          Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
+          please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C
+            Patent Policy Implementation</a>.</p>
+      </section>
+
+
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This <i class="todo">(Working|Interest)</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 5.2</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
+
+          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Initial Charter</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Charter Extension</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">none</i>
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a class="todo" href="">Rechartered</a>
+                </th>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <i class="todo">[dd monthname yyyy]</i>
+                </td>
+                <td>
+                  <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </section>
+    </main>
+
+    <hr>
+
+    <footer>
+      <address>
+        <i class="todo"><a href="mailto:">[team contact name]</a></i>
+      </address>
+
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> ©
+        <i class="todo">[yyyy]</i>
+        <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup>
+        (
+        <a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+        <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="https://www.keio.ac.jp/">Keio</a>,
+        <a href="https://ev.buaa.edu.cn/">Beihang</a>
+        ), All Rights Reserved.
+
+        <abbr title="World Wide Web Consortium">W3C</abbr> <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.
+      </p>
+      <hr>
+      <p><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</p>
+    </footer>
+
+  </body>
+</html>

--- a/math-2020.html
+++ b/math-2020.html
@@ -522,17 +522,6 @@ This may have an influence on the future evolution of MathML. Efforts to align M
             review</a>, this charter will be updated in place to use the updated Patent Policy.
         </p>
 
-        <h2>Patent Disclosures </h2>
-        <p>An Interest Group provides an opportunity to
-          share perspectives on the topic addressed by this charter. W3C reminds
-          Interest Group participants of their obligation to comply with patent
-          disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
-            6</a> of the W3C Patent Policy. While an Interest Group does not
-          produce Recommendation-track documents, when Interest Group
-          participants review Recommendation-track specifications from Working
-          Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
-          please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C
-            Patent Policy Implementation</a>.</p>
       </section>
 
 

--- a/math-2020.html
+++ b/math-2020.html
@@ -176,7 +176,7 @@ Wide adoption by browsers of a core set of presentational elements so that autho
 <li>
 Increased accessibility of Presentation MathML for both
 mathematics and chemical formulas achieved by allowing a means 
-of specifying relevant mathematical intent in-place, as well as by 
+of specifying relevant mathematical intent, as well as by 
 providing guidelines for interpreting Presentation MathML in the 
 absence of additional information.
 </li>

--- a/math-2020.html
+++ b/math-2020.html
@@ -72,10 +72,10 @@
 
 
     <main>
-      <h1 id="title"><i class="todo">PROPOSED MathML</i> Working Group Charter</h1>
+      <h1 id="title">PROPOSED MathML Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href="">MathML Working Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">MathML Working Group</a> is to promote the inclusion of mathematics on the Web so that it is a first class citizen of the web that displays well, is accessibility and is searchable.</p>
 
       <div class="noprint">
         <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the MathML Working Group.</a></p>
@@ -94,7 +94,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy] (date of the "Call for Participation", when the charter is approved)</i>
+              2021-01-04
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -102,22 +102,23 @@
               End date
             </th>
             <td>
-              <i class="todo">[dd monthname yyyy]</i>
+              2023-02-28
             </td>
           </tr>
-
-          <tr class="todo">
-            <th>Charter extension</th>
-            <td>See <a href="#history">Change History</a>.
-            </td>
-          </tr>
+	  <!--
+	  <tr class="todo">
+	     <th>Charter extension</th>
+											     <td>See <a href="#history">Change History</a>.
+											     </td>
+											  </tr>
+	  -->
 
           <tr>
             <th>
               Chairs
             </th>
             <td>
-              <i class="todo">[chair name] (affiliation)</i>
+              Neil Soiffer (Talking Cat Software)
             </td>
           </tr>
           <tr>
@@ -125,7 +126,7 @@
               Team Contacts
             </th>
             <td>
-              <span class="todo"><a href="mailto:">[team contact name]</a></span> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+              <a href="mailto:bert@w3.org">[Bert Bos]</a> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
             </td>
           </tr>
           <tr>
@@ -133,14 +134,13 @@
               Meeting Schedule
             </th>
             <td>
-              <strong>Teleconferences:</strong> <i class="todo">topic-specific calls may be held</i> or <i class="todo">somthing else</i>
+              <strong>Teleconferences:</strong> two 1 hour calls working on different aspects of MathML to be held weekly as needed to resolve issues
               <br>
-              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than 3 per year.
+              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; additional face-to-face meetings may be scheduled by consent of the participants, usually no more than one additional meeting per year.
             </td>
           </tr>
         </table>
 
-        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
       </section>
 
 
@@ -175,7 +175,7 @@ Wide adoption by browsers of a core set of presentational elements so that autho
 <li>
 Increased accessibility of Presentation MathML for both
 mathematics and chemical formulas by allowing a means 
-of specifying relevant semantics in-place, as well as providing guidelines for interpreting Presentation MathML in the absence of specific semantics.
+of specifying relevant mathematical intent in-place, as well as providing guidelines for interpreting Presentation MathML in the absence of other information.
 </li>
 <li>
 Ensuring that mathematical formulations are searchable.
@@ -260,16 +260,8 @@ Adding new elements for use exclusively outside the platform
 <p>This specification provides an initial integration into the Web Platform with increased implementation details, focusing on a subset of MathML 3 which has had wide implementation and fits well with the platform. It details and relies on automated Web Platform tests to improve MathML interoperability. It provides the core layer of MathML support upon which MathML 4 can build, and authors can implement remaining features (by polyfills), or more generally extend MathML Core, using modern web technologies.</p>
 
 
-              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="draft-status"><b>Draft state:</b>  <a href="https://mathml-refresh.github.io/mathml-core/">Final Community Group Editor's Draft</a></p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
-   <dl><dt>
-    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
-      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.</p>
-      <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span></p>
-	<p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.</p>
-       </dt>
-      </dl>
     </dd>
 
 
@@ -282,41 +274,22 @@ accessibility mappings of elements and attributes.
 </p>
 
 
-              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="draft-status"><b>Draft state:</b> No draft </p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
-   <dl><dt>
-    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
-      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.</p>
-      <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span></p>
-      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.</p>
-    </dt>
-   </dl>
   </dd>
 
 
             <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
             <dd>
 <p>This specification will attempt to overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. 
-It may add methods to specify more specific semantic information on Presentation MathML elements to enhance accessibility and searchability of math.</p>
+It will add attributes that allow specification of mathematical intent on Presentation MathML elements to enhance accessibility and searchability of math.</p>
 
 
-              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
-              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
-   <dl><dt>
-    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
-      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.</p>
-      <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span></p>
-      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.</p>
-</dt>
-</dl>
+              <p class="draft-status"><b>Draft state:</b> <a href="https://mathml-refresh.github.io/mathml/">Community Group's Initial Revision of MathML 3</a></p>
+              <p class="milestone"><b>Expected completion:</b> Q4 2022</p>
     </dd>
 
-
 	  </dl>
-
-<p>Where the MathML Core specifications are intended to define only those parts of MathML that are or will be implemented by all major browser engines.</p>
 
         </section>
 
@@ -330,9 +303,7 @@ It may add methods to specify more specific semantic information on Presentation
 <ul>
 <li>Test suites and implementation reports for the specification</li>
 <li>MathML Accessibility Techniques</li>
-<li>Guides on annotating Presentation MathML for accessibility and search including:</li>
-</ul>
-<ul>
+<li>Guides on annotating Presentation MathML for accessibility and search</li>
 <li>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</li>
 <li>Sample code that employs heuristics to adds accessibility/searchability annotations to Presentation MathML that lacks those annotations.</li>
 <li>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</li>
@@ -362,7 +333,7 @@ It may add methods to specify more specific semantic information on Presentation
 <p>The MathML Working Group&rsquo;s work is considered a success if:</p>
 <ul>
 <li>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used</li>
-<li>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core and semantics features by authoring tools/MathML converters.</li>
+<li>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core features aimed at improving accessibility by authoring tools/MathML converters.</li>
 <li>There is proven advancement and interest by implementers in MathML Core Level 2, exploring linking, better alignment with how the larger Web Platform evolves (Shadow DOM, Custom Elements, CSS)</li>
 <li>A MathML Full (MathML 4) specification, based on Core</li>
 <li>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
@@ -577,7 +548,6 @@ This may have an influence on the future evolution of MathML. Efforts to align M
           <h3>
             Charter History
           </h3>
-          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
 
           <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 5.2.3)</a>:</p>
 
@@ -602,15 +572,15 @@ This may have an influence on the future evolution of MathML. Efforts to align M
                   <a class="todo" href="">Initial Charter</a>
                 </th>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
+                  4 January, 2021
                 </td>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
+                  28 February, 2023
                 </td>
                 <td>
-                  <i class="todo">none</i>
                 </td>
               </tr>
+	      <!--
               <tr>
                 <th>
                   <a class="todo" href="">Charter Extension</a>
@@ -639,6 +609,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
                   <p class="todo">[description of change to charter, with link to new deliverable item in charter] <b>Note:</b> use the class <code>new</code> for all new deliverables, for ease of recognition.</p>
                 </td>
               </tr>
+	      -->
             </tbody>
           </table>
         </section>

--- a/math-2020.html
+++ b/math-2020.html
@@ -150,8 +150,6 @@
 
 	<section id="background">
 	  <h3>Background and Motivation</h3>
-</li>
-</ol>
 <p>
 <a href="https://www.w3.org/Math/">MathML </a>
 is a markup language for encoding and sharing mathematics.The need for mathematical rendering on the web
@@ -219,9 +217,6 @@ Integration of new and existing Web Platform technologies, including, but not li
 <li>Shadow DOM and Custom Elements</li>
 <li>CSS</li>
 </ul>
-</li>
-</ul>
-<ul>
 <li>Integration with tools above and beyond browsers</li>
 <li>Improvements to the MathML markup and processing model to enhance accessibility and searchability</li>
 <li>Identification of normative requirements needed to ensure accessibility</li>

--- a/math-2020.html
+++ b/math-2020.html
@@ -217,6 +217,7 @@ Integration of new and existing Web Platform technologies, including, but not li
 <li>Shadow DOM and Custom Elements</li>
 <li>CSS</li>
 </ul>
+</li>
 <li>Integration with tools above and beyond browsers</li>
 <li>Improvements to the MathML markup and processing model to enhance accessibility and searchability</li>
 <li>Identification of normative requirements needed to ensure accessibility</li>
@@ -263,10 +264,12 @@ Adding new elements for use exclusively outside the platform
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
    <dl><dt>
     <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
-      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.</p>
       <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span></p>
+	<p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.</p>
+       </dt>
+      </dl>
     </dd>
 
 
@@ -283,11 +286,13 @@ accessibility mappings of elements and attributes.
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
    <dl><dt>
     <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
-      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.</p>
       <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
-    </dd>
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span></p>
+      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.</p>
+    </dt>
+   </dl>
+  </dd>
 
 
             <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
@@ -300,14 +305,16 @@ It may add methods to specify more specific semantic information on Presentation
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
    <dl><dt>
     <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
-      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.</p>
       <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
-        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span></p>
+      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.</p>
+</dt>
+</dl>
     </dd>
 
 
-	  </dl></dl>
+	  </dl>
 
 <p>Where the MathML Core specifications are intended to define only those parts of MathML that are or will be implemented by all major browser engines.</p>
 

--- a/math-2020.html
+++ b/math-2020.html
@@ -281,7 +281,7 @@ accessibility mappings of elements and attributes.
             <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
             <dd>
 <p>This specification will overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. 
-It will add attributes that allow specification of mathematical intent on Presentation MathML elements to enhance accessibility and searchability of math.</p>
+It will allow specification of mathematical intent on Presentation MathML elements to enhance accessibility and searchability of math.</p>
 
 
               <p class="draft-status"><b>Draft state:</b> <a href="https://mathml-refresh.github.io/mathml/">Community Group's Initial Revision of MathML 3</a></p>
@@ -306,7 +306,6 @@ It will add attributes that allow specification of mathematical intent on Presen
 <li>MathML Accessibility Techniques</li>
 <li>Guides on annotating Presentation MathML for accessibility and search</li>
 <li>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</li>
-<li>Sample code that converts default "intent" values to explict "intent" values in Presentation MathML.</li>
 <li>At least one TeX-to-MathML converter that incorporates accessibility/searchability annotations in its MathML output.
 <li>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</li>
 <li>Sample code for conversion of annotated Presentation MathML to an external form such as speech and/or Content MathML</li>

--- a/math-2020.html
+++ b/math-2020.html
@@ -180,39 +180,39 @@ mathematics and chemical formulas by allowing a means
 of specifying relevant semantics in-place, as well as providing guidelines for interpreting Presentation MathML in the absence of specific semantics.
 </li>
 <li>
-<span>Ensuring that mathematical formulations are searchable.</span>
+Ensuring that mathematical formulations are searchable.
 </li>
 </ul>
 <p>
-<span>The Working Group will begin by providing a thorough review and refinement of MathML Core Level 1, a restricted form of MathML created by the MathML Community Group, which has done the initial hard work of largely aligning with features of the platform and precisely defining its rendering, including integration with CSS and basic DOM, providing tests and opening bugs.</span>
+The Working Group will begin by providing a thorough review and refinement of MathML Core Level 1, a restricted form of MathML created by the MathML Community Group, which has done the initial hard work of largely aligning with features of the platform and precisely defining its rendering, including integration with CSS and basic DOM, providing tests and opening bugs.
 </p>
 <p>
-<span>The Working Group will take up new work, such as problems the CG identified as requiring better solutions in order to move MathML in the Web Platform forward, in MathML Core Level 2.</span>
+The Working Group will take up new work, such as problems the CG identified as requiring better solutions in order to move MathML in the Web Platform forward, in MathML Core Level 2.
 </p>
 <p>
-<span>The Working Group will also overhaul MathML 3 building upon these fundamentals and experience with needs for accessibility and with many years of practical experience and use (or lack thereof), to create a path forward as MathML 4</span>
+The Working Group will also overhaul MathML 3 building upon these fundamentals and experience with needs for accessibility and with many years of practical experience and use (or lack thereof), to create a path forward as MathML 4.
 </p>
 <p>
-<span>The scope of the MathML Working Group includes the following:</span>
+The scope of the MathML Working Group includes the following:
 </p>
 <ul>
 <li>
-<span>Development of Recommendations as outlined above.</span>
+Development of Recommendations as outlined above.
 </li>
 <li>
-<span>Development of a test suite to check conformance of implementations.</span>
+Development of a test suite to check conformance of implementations.
 </li>
 <li>
-<span>Clarifications to the current use of Web Platform technologies, such as supported JavaScript APIs and CSS modules.</span>
+Clarifications to the current use of Web Platform technologies, such as supported JavaScript APIs and CSS modules.
 </li>
 <li>
-<span>Enhancements and improvements to internationalization.</span>
+Enhancements and improvements to internationalization.
 </li>
 <li>
-<span>Continued integration of errata and bug fixes.</span>
+Continued integration of errata and bug fixes.
 </li>
 <li>
-<span>Integration of new and existing Web Platform technologies, including, but not limited to:</span>
+Integration of new and existing Web Platform technologies, including, but not limited to:
 </li>
 </ul>
 <ul>
@@ -233,7 +233,7 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
 
 <ul>
 <li>
-<span>Adding new elements for use exclusively outside the platform</span>
+Adding new elements for use exclusively outside the platform
 </li>
 <li>Changes that would cause legacy MathML that has significant usage to stop working on the Web Platform or elsewhere.</li>
 <li>Changes to Content MathML. These will be considered at a later time after gaining experience and feedback from proposed additions to enhance accessibility and searchability in Presentation MathML.</li>
@@ -261,7 +261,7 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
           <dl>
             <dt id="mathml-core1" class="spec"><a href="#">MathML Core Level 1</a></dt>
             <dd>
-<p><span>This specification provides an initial integration into the Web Platform with increased implementation details, focusing on a subset of MathML 3 which has had wide implementation and fits well with the platform. It details and relies on automated Web Platform tests to improve MathML interoperability. It provides the core layer of MathML support upon which MathML 4 can build, and authors can implement remaining features (by polyfills), or more generally extend MathML Core, using modern web technologies.</p>
+<p>This specification provides an initial integration into the Web Platform with increased implementation details, focusing on a subset of MathML 3 which has had wide implementation and fits well with the platform. It details and relies on automated Web Platform tests to improve MathML interoperability. It provides the core layer of MathML support upon which MathML 4 can build, and authors can implement remaining features (by polyfills), or more generally extend MathML Core, using modern web technologies.</p>
 
 
               <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
@@ -279,8 +279,8 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
 
             <dt id="mathml-core2" class="spec"><a href="#">MathML Core Level 2</a></dt>
             <dd>
-<p>This specification will address features left out of Level 1 due to time and implementation constraints. It will provide guidance on improving MathML within the evolving web platform and enhancing the descriptions of generally polyfilling or extending MathML, using technologies such as a shadow DOM, custom elements, CSS layout API or other Houdini APIs. It will also address questions such as linking and accessibility through suggested </span>
-<span>accessibility mappings of elements and attributes.</span>
+<p>This specification will address features left out of Level 1 due to time and implementation constraints. It will provide guidance on improving MathML within the evolving web platform and enhancing the descriptions of generally polyfilling or extending MathML, using technologies such as a shadow DOM, custom elements, CSS layout API or other Houdini APIs. It will also address questions such as linking and accessibility through suggested 
+accessibility mappings of elements and attributes.
 </p>
 
 
@@ -297,8 +297,8 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
 
             <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
             <dd>
-<p>This specification will attempt to overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. </span>
-<span>It may add methods to specify more specific semantic information on Presentation MathML elements to enhance accessibility and searchability of math.</p>
+<p>This specification will attempt to overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. 
+It may add methods to specify more specific semantic information on Presentation MathML elements to enhance accessibility and searchability of math.</p>
 
 
               <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
@@ -326,31 +326,15 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
             Other non-normative documents may be created such as:
           </p>
 <ul>
-<li>
-<span>Test suites and implementation reports for the specification</span>
-</li>
-<li>
-<span>MathML Accessibility Techniques</span>
-</li>
-<li>
-<span>Guides on annotating</span>
-<span>&nbsp;Presentation MathML</span>
-<span>&nbsp;for accessibility and search including:</span>
-</li>
+<li>Test suites and implementation reports for the specification</li>
+<li>MathML Accessibility Techniques</li>
+<li>Guides on annotating Presentation MathML for accessibility and search including:</li>
 </ul>
 <ul>
-<li>
-<span>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</span>
-</li>
-<li>
-<span>Sample code that employs heuristics to adds accessibility/searchability annotations to Presentation MathML that lacks those annotations.</span>
-</li>
-<li>
-<span>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</span>
-</li>
-<li>
-<span>Sample code for conversion of annotated Presentation MathML to an external form such as speech and/or Content MathML </span>
-</li>
+<li>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</li>
+<li>Sample code that employs heuristics to adds accessibility/searchability annotations to Presentation MathML that lacks those annotations.</li>
+<li>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</li>
+<li>Sample code for conversion of annotated Presentation MathML to an external form such as speech and/or Content MathML</li>
 </ul>
 
         </section>
@@ -373,34 +357,15 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
 
-<p>
-<span>The MathML Working Group&rsquo;s work is considered a success if:</span>
-</p>
+<p>The MathML Working Group&rsquo;s work is considered a success if:</p>
 <ul>
-<li>
-<span>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used</span>
-</li>
-<li>
-<span>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core and semantics features by authoring tools/MathML converters.</span>
-</li>
-<li>
-<span>There is proven advancement and interest by implementers in MathML Core Level 2, exploring linking, better alignment with how the larger Web Platform evolves &nbsp;(Shadow DOM, Custom Elements, CSS)</span>
-</li>
-<li>
-<span>A MathML Full (MathML 4) specification, based on Core</span>
-</li>
-<li>
-<span>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</span>
-</li>
-<li>
-<span>There are significant testing plans and all testable changes have tests.</span>
-</li>
-<li>
-<span>There is an AAM (</span>
-<span>Accessibility</span>
-<span>&nbsp;API Mapping) </span>
-<span>for MathML Core and there are considerations of the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</span>
-</li>
+<li>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used</li>
+<li>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core and semantics features by authoring tools/MathML converters.</li>
+<li>There is proven advancement and interest by implementers in MathML Core Level 2, exploring linking, better alignment with how the larger Web Platform evolves (Shadow DOM, Custom Elements, CSS)</li>
+<li>A MathML Full (MathML 4) specification, based on Core</li>
+<li>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</li>
+<li>There are significant testing plans and all testable changes have tests.</li>
+<li>There is an AAM (Accessibility API Mapping) for MathML Core and there are considerations of the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</li>
 </ul>
 
 	</section>
@@ -425,23 +390,26 @@ of specifying relevant semantics in-place, as well as providing guidelines for i
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
 	    <dt><a href="https://www.w3.org/Style/CSS/">CSS Working Group</a></dt>
-	    <dd><span>The MathML Working Group will contribute to and coordinate work with the CSS Working Group related to aligning the development and testing of new and existing CSS functionalities that are of interest to the MathML community. The group will designate liaisons to work with the CSS Working Group on issues as needed. Liaisons will ideally be participants of both groups.</span></dd>
+	    <dd>The MathML Working Group will contribute to and coordinate work with the CSS Working Group related to aligning the development and testing of new and existing CSS functionalities that are of interest to the MathML community. The group will designate liaisons to work with the CSS Working Group on issues as needed. Liaisons will ideally be participants of both groups.</dd>
 	    <dt><a href="https://www.w3.org/community/wicg/">Web Incubator Community Group (WICG)</a></dt>
-	    <dd><span>The Web Platform Incubator Community Group (</span>
-<span>
-<a href="https://www.w3.org/community/wicg/">WICG</a>
-</span>
-<span>) provides a lightweight venue for proposing and discussing new web platform features, like new HTML features or Web Platform API-s. Also, new technical features arising during the development of MathML may have relevance for the Web Platform in general, or ideas developing for the Web Platform in general might be developing in </span>
+	    <dd>The Web Platform Incubator Community Group
+	      (<a href="https://www.w3.org/community/wicg/">WICG</a>)
+	      provides a lightweight venue for proposing and
+	      discussing new web platform features, like new HTML
+	      features or Web Platform API-s. Also, new technical
+	      features arising during the development of MathML may
+	      have relevance for the Web Platform in general, or ideas
+	      developing for the Web Platform in general might be
+	      developing in
 <a href="https://www.w3.org/community/wicg">WICG</a>
 which could be relevant to MathML. The MathML WG will make an effort to make sure these are explored further together within incubations in the Web Platform Incubator Community Group where appropriate.
 	    </dd>
 
 	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
-	    <dd><span>The APA WG provides horizontal review of potential accessibility issues in the architecture, including knowledge domains for STEM accessibility; as well as accessibility impact of a specification. The MathML WG will request reviews and coordinate, and may nominate liaisons to ensure that these groups are aligned and working in concert toward accessible mathematics.</span>
-</dd>
+	    <dd>The APA WG provides horizontal review of potential accessibility issues in the architecture, including knowledge domains for STEM accessibility; as well as accessibility impact of a specification. The MathML WG will request reviews and coordinate, and may nominate liaisons to ensure that these groups are aligned and working in concert toward accessible mathematics.</dd>
 
 	    <dt><a href="https://www.w3.org/WAI/ARIA/">ARIA Working Group</a></dt>
-	    <dd><span>The ARIA Working Group is responsible for the development of ARIA and related Accessibility Mappings. The MathML WG will appoint a liaison and coordinate with the ARIA Working Group to provide the </span>
+	    <dd>The ARIA Working Group is responsible for the development of ARIA and related Accessibility Mappings. The MathML WG will appoint a liaison and coordinate with the ARIA Working Group to provide the
 <a href="">MathML AAM</a>
 and continue to improve the accessibility of that which is part of MathML.
 </dd>
@@ -450,19 +418,12 @@ and continue to improve the accessibility of that which is part of MathML.
 	    <dd>The Publishing Working Group goal is to enable all publications to be first class citizens of the web. MathML is used by a large number of technical and textbook publishers in their workflows. The MathML WG will work with the PWG to ensure their needs are met with updates to the MathML recommendations.</dd>
 
 	    <dt><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></dt>
-	    <dd><span>The SVG Working Group is responsible for the development of </span>
-<span>
-<a href="https://www.w3.org/TR/SVG11/">SVG</a>
-</span>
-<span>. While largely non-overlapping technically, the two share similar origin stories and are both unique in their integration with the HTML Parser specification and integration as </span>
-<span>
-<a href="https://html.spec.whatwg.org/multipage/dom.html%23embedded-content-category">embedded content</a>
-</span>
-<span>. As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in proving common developer experiences and expectations. The MathML Working Group will make attempts to coordinate furthering these efforts together with the SVG Working Group (and the </span>
-<span>
-<a href="https://www.w3.org/community/svgcg/">SVG CG</a>
-</span>
-<span>).</span>
+	    <dd>The SVG Working Group is responsible for the development of
+<a href="https://www.w3.org/TR/SVG11/">SVG</a>.
+While largely non-overlapping technically, the two share similar origin stories and are both unique in their integration with the HTML Parser specification and integration as
+<a href="https://html.spec.whatwg.org/multipage/dom.html%23embedded-content-category">embedded content</a>.
+As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in proving common developer experiences and expectations. The MathML Working Group will make attempts to coordinate furthering these efforts together with the SVG Working Group (and the
+<a href="https://www.w3.org/community/svgcg/">SVG CG</a>).
 	    </dd>
 
 	    <dt><a href="https://www.w3.org/community/chem-web-pub/">Chemistry for the Web and Publishing Community Group</a></dt>

--- a/math-2020.html
+++ b/math-2020.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title><i class="todo">[name]</i> (Working|Interest) Group Charter</title>
+    <title><i>Math</i> Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -59,7 +59,6 @@
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
           <li><a href="#decisions">Decision Policy</a></li>
-          <i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i>
           <li><a href="#patentpolicy">Patent Policy</a></li>
           <li><a href="#patentpolicy">Patent Disclosures</a></li>
           <li><a href="#licensing">Licensing</a></li>
@@ -73,13 +72,13 @@
 
 
     <main>
-      <h1 id="title"><i class="todo">PROPOSED [name]</i> (Working|Interest) Group Charter</h1>
+      <h1 id="title"><i class="todo">PROPOSED Math</i> Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">Math</i> Working Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the <i class="todo">Math</i> Working Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -152,7 +151,7 @@
 
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
-            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+            <p>The following features are out of scope, and will not be addressed by this <i class="todo">Working</i> group.</p>
 
             <ul class="out-of-scope">
             </ul>
@@ -174,7 +173,7 @@
             Normative Specifications
           </h3>
           <p>
-            The <i class="todo">(Working|Interest)</i> Group will deliver the following W3C normative specifications:
+            The <i class="todo">Working</i> Group will deliver the following W3C normative specifications:
           </p>
           <dl>
             <dt id="web-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
@@ -236,13 +235,13 @@
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all specifications, this <i class="todo">(Working|Interest)</i> Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
+        <p>For all specifications, this <i class="todo">Working</i> Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
           accessibility, internationalization, performance, privacy, and security with the relevant Working and
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
           <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
-          <i class="todo">(Working|Interest)</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The <i class="todo">(Working|Interest)</i> Group is advised to seek a review at least 3 months before first entering
+          <i class="todo">Working</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The <i class="todo">Working</i> Group is advised to seek a review at least 3 months before first entering
           <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
           to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
@@ -278,7 +277,7 @@
           Participation
         </h2>
         <p>
-          To be successful, this <i class="todo">(Working|Interest)</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the (Working|Interest) Group. There is no minimum requirement for other Participants.
+          To be successful, this <i class="todo">Working</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
@@ -297,14 +296,14 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this <i class="todo">(Working|Interest)</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
+          Technical discussions for this <i class="todo">Working</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">[name]</i> (Working|Interest) Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">Math</i> Working Group home page.</a>
         </p>
         <p>
-          Most <i class="todo">[name]</i> (Working|Interest) Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most <i class="todo">Math</i> Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
           This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
@@ -332,7 +331,7 @@
 
           A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
 
-          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">(Working|Interest)</i> Group.
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">Working</i> Group.
         </p>
         <p>
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
@@ -380,7 +379,7 @@
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This <i class="todo">(Working|Interest)</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This <i class="todo">Working</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
       </section>
 
 

--- a/math-2020.html
+++ b/math-2020.html
@@ -510,7 +510,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
         <p>
           To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
 
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from 10 to 20 working days, depending on the chair's evaluation of the group consensus on the issue.
 
           If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>

--- a/math-2020.html
+++ b/math-2020.html
@@ -126,7 +126,7 @@
               Team Contacts
             </th>
             <td>
-              <a href="mailto:bert@w3.org">[Bert Bos]</a> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
+              <a href="mailto:bert@w3.org">[Bert Bos]</a> <i class="todo">(0.05 <abbr title="Full-Time Equivalent">FTE</abbr>)</i>
             </td>
           </tr>
           <tr>

--- a/math-2020.html
+++ b/math-2020.html
@@ -75,10 +75,10 @@
       <h1 id="title"><i class="todo">PROPOSED MathML</i> Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">MathML</i> Working Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href="">MathML Working Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the <i class="todo">MathML</i> Working Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the MathML Working Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -243,7 +243,7 @@ Adding new elements for use exclusively outside the platform
           Deliverables
         </h2>
 
-        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/[groupname]/PubStatus">group publication status page</a>.</p>
+        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/MathML/PubStatus">group publication status page</a>.</p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 
@@ -490,7 +490,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
           Most MathML Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          This group primarily conducts its technical work  on <a id="public-github" href="https://github.com/mathml-refresh/mathml/issues">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>

--- a/math-2020.html
+++ b/math-2020.html
@@ -510,18 +510,10 @@ This may have an influence on the future evolution of MathML. Efforts to align M
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 5 February 2004 updated 1 August 2017). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
+	This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Recommendations that can be implemented, according to this policy, on a Royalty-Free basis.
 
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/2004/01/pp-impl/">W3C Patent Policy Implementation</a>.
         </p>
-
-        <p>
-          If the Director approves the proposed <a href='https://www.w3.org/2020/06/DRAFT-PP2020.html'>W3C Patent
-            Policy (Draft dated 23 June 2020)</a>, without making substantive changes following the <a
-            href='https://lists.w3.org/Archives/Member/w3c-ac-members/2020JulSep/0002.html'>Advisory Committee
-            review</a>, this charter will be updated in place to use the updated Patent Policy.
-        </p>
-
       </section>
 
 

--- a/math-2020.html
+++ b/math-2020.html
@@ -213,13 +213,13 @@ Continued integration of errata and bug fixes.
 </li>
 <li>
 Integration of new and existing Web Platform technologies, including, but not limited to:
-</li>
-</ul>
 <ul>
 <li>Hyperlinks</li>
 <li>DOM APIs</li>
 <li>Shadow DOM and Custom Elements</li>
 <li>CSS</li>
+</ul>
+</li>
 </ul>
 <ul>
 <li>Integration with tools above and beyond browsers</li>
@@ -558,7 +558,7 @@ This may have an influence on the future evolution of MathML. Efforts to align M
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This <i class="todo">Working</i> Group will use the  <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This Working Group will use the  <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
       </section>
 
 

--- a/math-2020.html
+++ b/math-2020.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 
-    <title><i>Math</i> Working Group Charter</title>
+    <title><i>MathML</i> Working Group Charter</title>
 
     <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
@@ -72,13 +72,13 @@
 
 
     <main>
-      <h1 id="title"><i class="todo">PROPOSED Math</i> Working Group Charter</h1>
+      <h1 id="title"><i class="todo">PROPOSED MathML</i> Working Group Charter</h1>
       <!-- delete PROPOSED after AC review completed -->
 
-      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">Math</i> Working Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">MathML</i> Working Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the <i class="todo">Math</i> Working Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the <i class="todo">MathML</i> Working Group.</a></p>
       </div>
 
          <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
@@ -147,17 +147,100 @@
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
-        <p><i class="todo">Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry.</i></p>
 
-        <section id="section-out-of-scope">
-          <h3 id="out-of-scope">Out of Scope</h3>
-            <p>The following features are out of scope, and will not be addressed by this <i class="todo">Working</i> group.</p>
+	<section id="background">
+	  <h3>Background and Motivation</h3>
+</li>
+</ol>
+<p>
+<a href="https://www.w3.org/Math/">MathML </a>
+is a markup language for encoding and sharing mathematics.The need for mathematical rendering on the web
+was evident from the
+<a href="https://www.w3.org/MarkUp/HTMLPlus/htmlplus_45.html">earliest days of the Web at CERN</a>,
+and MathML was among the first specifications taken up and developed by the W3C in the mid/late-1990&#39;s XML/XHTML era. It received much attention and has created a vibrant ecosystem of implementations and integration outside of web browsers, and it advanced on the Web itself becoming integrated, along with SVG into the HTML Parser and the HTML Specification in the mid 2000s. Since then, much has happened. While MathML has much
+success with making math accessible
+and has had wide adoption by the tools used to generate and consume math, browser adoption is not universal. The MathML 3 specification does not match some current Web realities; it does not contain precise enough requirements for interoperability within the Web Platform; and some features are either incompatible with or subsumed by new features added to the Web Platform outside MathML.
+</p>
+</section>
 
-            <ul class="out-of-scope">
-            </ul>
-        </section>
+      <section id="scope-inscope" class="scope">
+        <h3>Scope</h3>
 
-      </section>
+
+<p>
+The MathML Refresh Community Group (CG) was formed to revise MathML to address perceived deficiencies in the spec. The MathML Working Group will advance, refine, and clarify the work begun by the MathML Community Group and ensure MathML&rsquo;s relevance continues to evolve, grow and improve. In particular, there are three goals the group hopes to advance:
+</p>
+<ul>
+<li>
+Wide adoption by browsers of a core set of presentational elements so that authors can be assured that math will be displayed similarly in all browsers without having to rely on external libraries to do the display.
+</li>
+<li>
+Increased accessibility of Presentation MathML for both
+mathematics and chemical formulas by allowing a means 
+of specifying relevant semantics in-place, as well as providing guidelines for interpreting Presentation MathML in the absence of specific semantics.
+</li>
+<li>
+<span>Ensuring that mathematical formulations are searchable.</span>
+</li>
+</ul>
+<p>
+<span>The Working Group will begin by providing a thorough review and refinement of MathML Core Level 1, a restricted form of MathML created by the MathML Community Group, which has done the initial hard work of largely aligning with features of the platform and precisely defining its rendering, including integration with CSS and basic DOM, providing tests and opening bugs.</span>
+</p>
+<p>
+<span>The Working Group will take up new work, such as problems the CG identified as requiring better solutions in order to move MathML in the Web Platform forward, in MathML Core Level 2.</span>
+</p>
+<p>
+<span>The Working Group will also overhaul MathML 3 building upon these fundamentals and experience with needs for accessibility and with many years of practical experience and use (or lack thereof), to create a path forward as MathML 4</span>
+</p>
+<p>
+<span>The scope of the MathML Working Group includes the following:</span>
+</p>
+<ul>
+<li>
+<span>Development of Recommendations as outlined above.</span>
+</li>
+<li>
+<span>Development of a test suite to check conformance of implementations.</span>
+</li>
+<li>
+<span>Clarifications to the current use of Web Platform technologies, such as supported JavaScript APIs and CSS modules.</span>
+</li>
+<li>
+<span>Enhancements and improvements to internationalization.</span>
+</li>
+<li>
+<span>Continued integration of errata and bug fixes.</span>
+</li>
+<li>
+<span>Integration of new and existing Web Platform technologies, including, but not limited to:</span>
+</li>
+</ul>
+<ul>
+<li>Hyperlinks</li>
+<li>DOM APIs</li>
+<li>Shadow DOM and Custom Elements</li>
+<li>CSS</li>
+</ul>
+<ul>
+<li>Integration with tools above and beyond browsers</li>
+<li>Improvements to the MathML markup and processing model to enhance accessibility and searchability</li>
+<li>Identification of normative requirements needed to ensure accessibility</li>
+<li>Removing elements and attributes from MathML that have had minimal adoption</li>
+</ul>
+</section>
+<section id="section-out-of-scope">
+  <h3 id="out-of-scope">Out of Scope</h3>
+
+<ul>
+<li>
+<span>Adding new elements for use exclusively outside the platform</span>
+</li>
+<li>Changes that would cause legacy MathML that has significant usage to stop working on the Web Platform or elsewhere.</li>
+<li>Changes to Content MathML. These will be considered at a later time after gaining experience and feedback from proposed additions to enhance accessibility and searchability in Presentation MathML.</li>
+</ul>
+</section>
+
+</section>
 
       <section id="deliverables">
         <h2>
@@ -173,12 +256,13 @@
             Normative Specifications
           </h3>
           <p>
-            The <i class="todo">Working</i> Group will deliver the following W3C normative specifications:
+            The Working Group will deliver the following W3C normative specifications:
           </p>
           <dl>
-            <dt id="web-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
+            <dt id="mathml-core1" class="spec"><a href="#">MathML Core Level 1</a></dt>
             <dd>
-              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+<p><span>This specification provides an initial integration into the Web Platform with increased implementation details, focusing on a subset of MathML 3 which has had wide implementation and fits well with the platform. It details and relies on automated Web Platform tests to improve MathML interoperability. It provides the core layer of MathML support upon which MathML 4 can build, and authors can implement remaining features (by polyfills), or more generally extend MathML Core, using modern web technologies.</p>
+
 
               <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
@@ -189,8 +273,48 @@
         <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
       <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
     </dd>
-              </dl></dl>
 
+
+
+
+            <dt id="mathml-core2" class="spec"><a href="#">MathML Core Level 2</a></dt>
+            <dd>
+<p>This specification will address features left out of Level 1 due to time and implementation constraints. It will provide guidance on improving MathML within the evolving web platform and enhancing the descriptions of generally polyfilling or extending MathML, using technologies such as a shadow DOM, custom elements, CSS layout API or other Houdini APIs. It will also address questions such as linking and accessibility through suggested </span>
+<span>accessibility mappings of elements and attributes.</span>
+</p>
+
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+   <dl><dt>
+    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
+      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
+      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
+    </dd>
+
+
+            <dt id="mathml4" class="spec"><a href="#">MathML 4</a></dt>
+            <dd>
+<p>This specification will attempt to overhaul the existing MathML 3 specification, rebasing it on MathML Core Level 1. It will deprecate, obsolete, or drop features that are not used and likely will not be used. </span>
+<span>It may add methods to specify more specific semantic information on Presentation MathML elements to enhance accessibility and searchability of math.</p>
+
+
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a> | <a href="#">Adopted from WG/CG Foo</a> | <a href="#">Working Draft</a>]</i></p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
+   <dl><dt>
+    <p class="todo">Per <a href="https://www.w3.org/Consortium/Process/#WGCharter">5.2.6</a>, for every Recommendation Track deliverable that continues work on a Working Draft (WD) published under any other Charter (including a predecessor group of the same name), for which there is an existing Reference Draft or Candidate Recommendation: </p>
+      <p><b>Adopted Working Draft:</b> The <span class="todo">title, stable URL, and publication date of the <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#adopted-draft">Adopted Working Draft</a></span> which will serve as the basis for work on the deliverable.
+      <p><b>Reference Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://github.com/w3c/charter-drafts/blob/gh-pages/draft-states.md#reference-draft'>Reference Draft</a> or Candidate Recommendation</span> which triggered an Exclusion Opportunity per the Patent Process.
+        <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
+      <p>Produced under <b>Working Group Charter:</b> The  <span class="todo">stable URL of the Working Group charter</span> under which the most recent Reference Draft or Candidate Recommendation was published.
+    </dd>
+
+
+	  </dl></dl>
+
+<p>Where the MathML Core specifications are intended to define only those parts of MathML that are or will be implemented by all major browser engines.</p>
 
         </section>
 
@@ -201,15 +325,39 @@
           <p>
             Other non-normative documents may be created such as:
           </p>
-          <ul>
-            <li>Use case and requirement documents;</li>
-            <li>Test suite and implementation report for the specification;</li>
-            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
-          </ul>
+<ul>
+<li>
+<span>Test suites and implementation reports for the specification</span>
+</li>
+<li>
+<span>MathML Accessibility Techniques</span>
+</li>
+<li>
+<span>Guides on annotating</span>
+<span>&nbsp;Presentation MathML</span>
+<span>&nbsp;for accessibility and search including:</span>
+</li>
+</ul>
+<ul>
+<li>
+<span>A living catalog for annotations beyond those defined in a MathML 4 recommendation.</span>
+</li>
+<li>
+<span>Sample code that employs heuristics to adds accessibility/searchability annotations to Presentation MathML that lacks those annotations.</span>
+</li>
+<li>
+<span>Code to convert Content MathML to Presentation MathML with accessibility and searchability annotations.</span>
+</li>
+<li>
+<span>Sample code for conversion of annotated Presentation MathML to an external form such as speech and/or Content MathML </span>
+</li>
+</ul>
+
         </section>
 
         <section id="timeline">
           <h3>Timeline</h3>
+	  <p>These dates are not meant as deadlines; work may need to continue after these dates to ensure the quality of the deliverables.</p>
             <p class="todo">Put here a timeline view of all deliverables.</p>
             <ul class="todo">
               <li>Month YYYY: First teleconference</li>
@@ -224,24 +372,48 @@
 
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
-	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
-	  <p>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
-	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
-		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
-		recommendations for maximising accessibility in implementations.</p>
-	  <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span> To promote interoperability, all changes made to specifications should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.</p>
+
+<p>
+<span>The MathML Working Group&rsquo;s work is considered a success if:</span>
+</p>
+<ul>
+<li>
+<span>There are independent, interoperable native implementations of MathML Core Level 1 that are widely used</span>
+</li>
+<li>
+<span>The larger Web Platform ecosystem shows signs of movement toward creating and using new MathML content, including direct use of core and semantics features by authoring tools/MathML converters.</span>
+</li>
+<li>
+<span>There is proven advancement and interest by implementers in MathML Core Level 2, exploring linking, better alignment with how the larger Web Platform evolves &nbsp;(Shadow DOM, Custom Elements, CSS)</span>
+</li>
+<li>
+<span>A MathML Full (MathML 4) specification, based on Core</span>
+</li>
+<li>
+<span>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</span>
+</li>
+<li>
+<span>There are significant testing plans and all testable changes have tests.</span>
+</li>
+<li>
+<span>There is an AAM (</span>
+<span>Accessibility</span>
+<span>&nbsp;API Mapping) </span>
+<span>for MathML Core and there are considerations of the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximizing accessibility in implementations.</span>
+</li>
+</ul>
+
 	</section>
 
       <section id="coordination">
         <h2>Coordination</h2>
-        <p>For all specifications, this <i class="todo">Working</i> Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
+        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/process/charter.html#horizontal-review">horizontal review</a> for
           accessibility, internationalization, performance, privacy, and security with the relevant Working and
           Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
           Invitation for review must be issued during each major standards-track document transition, including
           <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
-          <i class="todo">Working</i> Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The <i class="todo">Working</i> Group is advised to seek a review at least 3 months before first entering
+          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
           <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
           to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
 
@@ -252,8 +424,49 @@
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
-            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
+	    <dt><a href="https://www.w3.org/Style/CSS/">CSS Working Group</a></dt>
+	    <dd><span>The MathML Working Group will contribute to and coordinate work with the CSS Working Group related to aligning the development and testing of new and existing CSS functionalities that are of interest to the MathML community. The group will designate liaisons to work with the CSS Working Group on issues as needed. Liaisons will ideally be participants of both groups.</span></dd>
+	    <dt><a href="https://www.w3.org/community/wicg/">Web Incubator Community Group (WICG)</a></dt>
+	    <dd><span>The Web Platform Incubator Community Group (</span>
+<span>
+<a href="https://www.w3.org/community/wicg/">WICG</a>
+</span>
+<span>) provides a lightweight venue for proposing and discussing new web platform features, like new HTML features or Web Platform API-s. Also, new technical features arising during the development of MathML may have relevance for the Web Platform in general, or ideas developing for the Web Platform in general might be developing in </span>
+<a href="https://www.w3.org/community/wicg">WICG</a>
+which could be relevant to MathML. The MathML WG will make an effort to make sure these are explored further together within incubations in the Web Platform Incubator Community Group where appropriate.
+	    </dd>
+
+	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
+	    <dd><span>The APA WG provides horizontal review of potential accessibility issues in the architecture, including knowledge domains for STEM accessibility; as well as accessibility impact of a specification. The MathML WG will request reviews and coordinate, and may nominate liaisons to ensure that these groups are aligned and working in concert toward accessible mathematics.</span>
+</dd>
+
+	    <dt><a href="https://www.w3.org/WAI/ARIA/">ARIA Working Group</a></dt>
+	    <dd><span>The ARIA Working Group is responsible for the development of ARIA and related Accessibility Mappings. The MathML WG will appoint a liaison and coordinate with the ARIA Working Group to provide the </span>
+<a href="">MathML AAM</a>
+and continue to improve the accessibility of that which is part of MathML.
+</dd>
+
+	    <dt><a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working Group</a></dt>
+	    <dd>The Publishing Working Group goal is to enable all publications to be first class citizens of the web. MathML is used by a large number of technical and textbook publishers in their workflows. The MathML WG will work with the PWG to ensure their needs are met with updates to the MathML recommendations.</dd>
+
+	    <dt><a href="https://www.w3.org/Graphics/SVG/">SVG Working Group</a></dt>
+	    <dd><span>The SVG Working Group is responsible for the development of </span>
+<span>
+<a href="https://www.w3.org/TR/SVG11/">SVG</a>
+</span>
+<span>. While largely non-overlapping technically, the two share similar origin stories and are both unique in their integration with the HTML Parser specification and integration as </span>
+<span>
+<a href="https://html.spec.whatwg.org/multipage/dom.html%23embedded-content-category">embedded content</a>
+</span>
+<span>. As such they have many similar challenges and efforts to align with the larger Web Platform and share common interests in proving common developer experiences and expectations. The MathML Working Group will make attempts to coordinate furthering these efforts together with the SVG Working Group (and the </span>
+<span>
+<a href="https://www.w3.org/community/svgcg/">SVG CG</a>
+</span>
+<span>).</span>
+	    </dd>
+
+	    <dt><a href="https://www.w3.org/community/chem-web-pub/">Chemistry for the Web and Publishing Community Group</a></dt>
+	    <dd>Chemical Formulas make use of mathematical notations. The Chem CG is concerned about the accessibility challenges of using math notations and having them spoken and brailled appropriately. The Math CG has worked with the Chem CG to ensure appropriate access to chemical formulas and the MathML WG will continue this effort.</dd>
           </dl>
 
           <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
@@ -264,8 +477,16 @@
         <section>
           <h3 id="external-coordination">External Organizations</h3>
           <dl>
-            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
+            <dt><a href="https://whatwg.org/">WHATWG</a></dt>
+            <dd>The
+<a href="https://whatwg.org/">WHATWG</a>
+is responsible for the development of
+<a href="https://html.spec.whatwg.org/multipage/">HTML</a>
+and
+<a href="https://dom.spec.whatwg.org/">DOM</a>.
+This may have an influence on the future evolution of MathML. Efforts to align MathML Core with the Web Platform may lead to alignment requirements for these (new IDL, focusability, support for ideas like ShadowDOM, support for attributes, etc), in which case these should be explored further together with the WHATWG (and the
+<a href="https://www.w3.org/community/wicg/">WICG</a>).
+</dd>
           </dl>
         </section>
       </section>
@@ -277,7 +498,7 @@
           Participation
         </h2>
         <p>
-          To be successful, this <i class="todo">Working</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
+          To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
@@ -296,18 +517,17 @@
           Communication
         </h2>
         <p id="public">
-          Technical discussions for this <i class="todo">Working</i> Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
+          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository and may permit direct public contribution requests.
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href=""><i class="todo">Math</i> Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/Math">MathML Working Group home page.</a>
         </p>
         <p>
-          Most <i class="todo">Math</i> Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
+          Most MathML Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
-          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          This group primarily conducts its technical work  on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
@@ -331,7 +551,7 @@
 
           A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc'><i class="todo">[pick a duration within:] one week to 10 working days</i></span>, depending on the chair's evaluation of the group consensus on the issue.
 
-          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the <i class="todo">Working</i> Group.
+          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>
         <p>
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
@@ -344,8 +564,6 @@
 
 
       <section id="patentpolicy">
-      <p><i class="todo">[Keep 'Patent Policy' for a Working Group, 'Patent Disclosures' for an Interest Group]</i></p>
-
         <h2>
           Patent Policy
         </h2>
@@ -379,7 +597,7 @@
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This <i class="todo">Working</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This <i class="todo">Working</i> Group will use the  <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
       </section>
 
 


### PR DESCRIPTION
The MathML Refresh CG has developed a charter for a restart of the Math Working Group. We believe this is now ready for W3C review.