### PR TITLE
[template] separate sec and priv sections

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -226,7 +226,7 @@
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
 	  <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
-	  <p>Each specification should contain a section detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and


### PR DESCRIPTION
require separate sec and priv sections, consistent with https://w3ctag.github.io/security-questionnaire/#reviews and https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review