### PR TITLE
[template] add todo tag on publication status page text

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -165,7 +165,7 @@
           Deliverables
         </h2>
 
-        <p>More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/[groupname]/PubStatus">group publication status page</a>.</p>
+        <p><i class="todo">More detailed milestones and updated publication schedules are available on the <a href="https://www.w3.org/wiki/[groupname]/PubStatus">group publication status page</a>.</i></p>
 
         <p><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 


### PR DESCRIPTION
wrap a todo tag around the publication status text, as an interim step.  Thanks to @tguild for calling this out in https://github.com/w3c/automotive/issues/354.

IMHO, we should remove this entirely or replace it with something more likely to be used.   See https://github.com/w3c/charter-drafts/issues/297.