### PR TITLE
[template] remove Charter Extension line from header

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -107,13 +107,6 @@
               <i class="todo">[dd monthname yyyy]</i>
             </td>
           </tr>
-
-          <tr class="todo">
-            <th>Charter extension</th>
-            <td>See <a href="#history">Change History</a>.
-            </td>
-          </tr>
-
           <tr>
             <th>
               Chairs


### PR DESCRIPTION
Given how we're capturing that (in the history section and by pushing completely new files upon recharter), it seems to not belong there.