### PR TITLE
[PNG-2021] Avoid citing an Editor's Draft as if it were the /TR

### DIFF
--- a/png-2021.html
+++ b/png-2021.html
@@ -251,7 +251,7 @@
             The Working Group will deliver the following W3C normative specifications:
           </p>
           <dl>
-            <dt id="PNG-speco" class="spec"><a href="https://w3c.github.io/PNG-spec/">Portable Network Graphics (PNG) Specification (Third Edition)</a></dt>
+            <dt id="PNG-speco" class="spec"><!--<a href="https://w3c.github.io/PNG-spec/"-->Portable Network Graphics (PNG) Specification (Third Edition)<!--</a--></dt>
             <dd>
               <p>Derived from the 2003
                 <a href="https://www.w3.org/TR/2003/REC-PNG-20031110/">


### PR DESCRIPTION
The title "Portable Network Graphics (PNG) Specification (Third Edition)" belongs to a document that will eventually live in /TR.  There is already a citation to its Editor's Draft shortly after this name is used.  Until the document exists in /TR, the title should not be associated with a draft in GitHub.