### PR TITLE
[PNG-2021] Remove template notes

### DIFF
--- a/png-2021.html
+++ b/png-2021.html
@@ -350,9 +350,6 @@
             </dd>
           </dl>
 
-          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
-          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
-            Instead, put it in the scope section.</p>
         </section>
 
         <section>


### PR DESCRIPTION
The two notes in the Coordination section are extraneous for the final published proposed charter.