### PR TITLE
[SVG] Remove premature link to unpublished SVG Native draft

### DIFF
--- a/2021/svg.html
+++ b/2021/svg.html
@@ -282,7 +282,7 @@
           </dl>
           <dl>
             <dt id="native-svg" class="spec">
-              <a href="https://svgwg.org/specs/svg-native/">SVG Native</a>
+              <!--<a href="">-->SVG Native<!--</a>-->
             </dt>
             <dd>
               <p>


### PR DESCRIPTION
The title reference to the SVG Native draft should be reserved for when there is a /TR link.  The link to the editor's draft immediately below is sufficient.