### PR TITLE
Complete the description of work on extension specifications

### DIFF
--- a/html-2021.html
+++ b/html-2021.html
@@ -148,6 +148,9 @@
         workstreams,
         and to bring WHATWG HTML and DOM Review Drafts to Recommendation. The Working Group also has the ability
         to bring the Fetch review drafts to Recommendation.
+        The Working Group may also work on extension specifications for HTML features
+        in <a href='https://github.com/w3c/whatwg-coord/issues'>coordination with
+        the WHATWG Steering Group</a>.
       </p>
       <p>
         The community (including users, implementers, and developers) and horizontal review groups are encouraged to
@@ -180,7 +183,7 @@
             Normative Specifications
           </h3>
           <p>
-            The Working Group will deliver the following W3C normative specifications:
+            The Working Group will deliver the following W3C normative specifications based on WHATWG Living Standards:
           </p>
           <dl>
 
@@ -221,14 +224,14 @@
               <p class="draft-status"><b>Draft state:</b> <a href="https://fetch.spec.whatwg.org/">WHATWG Living
                   Standard</a></p>
             </dd>
+          </dl>
 
-       </dl>
+          <p>
+            The Working Group will work on the following extension specifications on the <a href="https://www.w3.org/Consortium/Process/#rec-track">Recommendation Track</a>:
+          </p>
 
-       <p>
-        The Working Group may also work on extension specifications for HTML features
-        after <a href='https://github.com/w3c/whatwg-coord/issues'>coordination with
-        the WHATWG Steering Group</a>.
-       </p>
+          <p>None yet.</p>
+
         </section>
 
         <section id="timeline">
@@ -294,6 +297,18 @@
           <p>The HTML Working Group is expected to endorse a WHATWG HTML or DOM Review Draft to Candidate Recommendation
             at least once per 12 month period.</p>
 
+          <p>
+            For extension specifications,
+            while coordination <a href="https://github.com/w3c/whatwg-coord/">as agreed with the WHATWG</a> is also expected,
+            the Working Group will follow the more standard approach
+            to <a href="https://www.w3.org/Consortium/Process/#Reports">technical report</a> development and publication:
+            the Working Group will appoint its own editors,
+            develop its own drafts,
+            accept and process feedback,
+            and progress the documents along the <a href="https://www.w3.org/Consortium/Process/#rec-track">Recommendation Track</a>
+            on the basis of its own consensus.
+          </p>
+
       </section>
 
 	<section id="success-criteria">
@@ -302,16 +317,21 @@
       The Working Group will bring one or more WHATWG Review Drafts from W3C Candidate Recommendation to Proposed
       Recommendation.
     </p>
-    <p>In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsCR"
+    <p>In order to advance WHATWG Review Drafts to <a href="https://www.w3.org/Consortium/Process/#RecsCR"
         title="Candidate Recommendation">Candidate Recommendation (CR)</a>, each feature is expected to be marked
       with its implementation status. The CR will indicate that all features with fewer than two implementations are
       at-risk.
     </p>
     <p>The <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed
         Recommendation (PR)</a> and <a href="https://www.w3.org/Consortium/Process/#RecsW3C"
-        title="Recommendation">Recommendation (REC)</a> endorsement will indicate that all features which do not
+        title="Recommendation">Recommendation (REC)</a> endorsement of WHATWG Review Drafts will indicate that all features which do not
       have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent
         implementations</a> are considered informative, not normative, for W3C purposes. </p>
+    <p>
+      In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>,
+      each extension specification
+      is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.
+    </p>
     <p>Each specification is encouraged to contain or point to considerations detailing all known security and
       privacy implications for implementers, Web authors, and end users.</p>
     <p>
@@ -426,6 +446,12 @@
             href="https://github.com/whatwg/">WHATWG GitHub repositories</a>. It may also use
           the public mailing list <a id="public-name" href="mailto:public-html@w3.org">public-html@w3.org</a> (<a
             href="https://lists.w3.org/Archives/Public/public-html/">archive</a>).
+        </p>
+        <p>
+          For extension specifications,
+          this group primarily conducts its technical work
+          through its own <a id="public-github-ext" href="https://github.com/w3c/htmlwg/">GitHub repositories</a>.
+          The public is invited to review, discuss and contribute to this work.
         </p>
       </section>
 


### PR DESCRIPTION
Include extensions in the scope, adjust existing phrasing meant to cover W3C
publication of WHATWG Living standards to scope it to that, and add
generic wording to handle work on extensions.