### PR TITLE
[tempate] No longer require separate sec/priv sections

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -233,7 +233,7 @@
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
 	  <p><span class='todo'>Remove this clause if the Group does not intend to move to REC:</span> In order to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent implementations</a> of every feature defined in the specification.</p>
-	  <p>Each specification should contain separate sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+	  <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and


### PR DESCRIPTION
Based on feedback, removing the hard requirement that security and privacy concerns be in different sections.  For history, see  https://github.com/w3c/charter-drafts/pull/300