### PR TITLE
editorial issues of the distributed-tracing 2022 charter

### DIFF
--- a/2022/distributed-tracing.html
+++ b/2022/distributed-tracing.html
@@ -157,6 +157,9 @@
 
       </div>
 
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+
       <div id="background" class="background">
         <p>
           Modern cloud-native applications are highly distributed and often span multiple technology and vendor boundaries. The complexity
@@ -164,9 +167,6 @@
           to as "tracing".
         </p>
       </div>
-
-      <section id="scope" class="scope">
-        <h2>Scope</h2>
         <p>
           Tracing tools for collecting the individual requests information have been available for quite some time. However, these tools have not been
           built with interoperability in mind. This leaves the developer with a number of challenges in getting an end-to-end
@@ -386,7 +386,7 @@ on 2020-10-20, ended on 2021-03-19.</p>
         The meetings themselves are not open to public participation, however.
         </p>
         <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="">Distributed Tracing Working Group home page.</a>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/groups/wg/distributed-tracing">Distributed Tracing Working Group home page.</a>
         </p>
         <p>
           Most Distributed Tracing Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.


### PR DESCRIPTION
* put the _background_ section back into the _Scope_.
* add a link to the WG homepage.