### PR TITLE
[template] remove 'all-known'

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -252,7 +252,7 @@ test suite of every feature defined in the specification.</p>
       Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
 
     <!-- Horizontal review -->
-    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
+    <p>Each specification should contain sections detailing security and privacy implications for implementers, Web authors, and end users.</p>
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>


### PR DESCRIPTION
@martinthomson wants to remove "all-known" as a way to deweaponize this requirement.  The PATCG was agreeable and also suggested we backport the change to the template. 
 https://github.com/patcg/patwg-charter/pull/60

I'm of mixed minds, but I'm creating the PR so we can discuss.