### PR TITLE
Encourage use of the correct license

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -407,7 +407,7 @@ test suite of every feature defined in the specification.</p>
 
       <section id="licensing">
         <h2>Licensing</h2>
-        <p>This <i class="todo">(Working|Interest)</i> Group will use the <i class="todo">[pick a license, one of:]</i>  <a href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document license</a> | <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+        <p>This <i class="todo">(Working|Interest)</i> Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
       </section>
 
 


### PR DESCRIPTION
Most working groups choose the more permissive "software and document" license.  Those who want the more restrictive "document" license will know that, so don't pave the path to that restrictive license.