### PR TITLE
[wg/did] change suggestion by @jyasskin

### DIFF
--- a/2023/did-wg.html
+++ b/2023/did-wg.html
@@ -316,7 +316,7 @@ more implementations interoperating with each other. In order to advance to
 Proposed Recommendation, each normative specification must have an open
 test suite of every feature defined in the specification.</p>
 
-    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independant implementations mentioned above support at least two DID methods with an open specification (i.e. a specification that is accessible to all for implementation and deployment). It is also expected that each pair of the independant implementations mentioned above support at least one common DID method with an open specification.</p>
+    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independant implementations mentioned above support at least two DID methods with open specifications at at least the Candidate Recommendation Snapshot level, or a level with equivalent vetting and patent grants at another standards body. It is also expected that each pair of the independant implementations mentioned above support at least one common DID method with an open specification.</p>
     </ul>
 
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>

--- a/2023/did-wg.html
+++ b/2023/did-wg.html
@@ -316,10 +316,12 @@ more implementations interoperating with each other. In order to advance to
 Proposed Recommendation, each normative specification must have an open
 test suite of every feature defined in the specification.</p>
 
-    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independent implementations mentioned above support at least two DID methods with open specifications
+    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independent implementations mentioned above support at least two DID methods which 1) have an open specifications
     (freely available specification, freely implementable),
-    and implemented interoperably by more than one
-    of the independent implementations mentioned above.</p>
+    and 2) are implemented interoperably by more than one
+    of the independent implementations mentioned above.
+    This means that there will exist at least two openly-specified DID methods that are each implemented by at least two independent implementations.
+    </p>
 
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 

--- a/2023/did-wg.html
+++ b/2023/did-wg.html
@@ -316,9 +316,10 @@ more implementations interoperating with each other. In order to advance to
 Proposed Recommendation, each normative specification must have an open
 test suite of every feature defined in the specification.</p>
 
-    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independant implementations mentioned above support at least two DID methods with open specifications
-    (i.e., accessible to all for implementaton and deployment) that is either at a CR snapshot level at the W3C (or a level with equivalent vetting and patent grants at another standard body) or has a large user community actively relying on that particular method.
-    It is also expected that each pair of the independant implementations mentioned above support at least one common DID method with an open specification.</p>
+    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independent implementations mentioned above support at least two DID methods with open specifications
+    (freely available specification, freely implementable),
+    and implemented interoperably by more than one
+    of the independent implementations mentioned above.</p>
 
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 

--- a/2023/did-wg.html
+++ b/2023/did-wg.html
@@ -316,8 +316,9 @@ more implementations interoperating with each other. In order to advance to
 Proposed Recommendation, each normative specification must have an open
 test suite of every feature defined in the specification.</p>
 
-    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independant implementations mentioned above support at least two DID methods with open specifications at at least the Candidate Recommendation Snapshot level, or a level with equivalent vetting and patent grants at another standards body. It is also expected that each pair of the independant implementations mentioned above support at least one common DID method with an open specification.</p>
-    </ul>
+    <p>In order for <a href="#deliverable-did-resolution">DID Resolution</a> to advance to <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, it is expected that each of the independant implementations mentioned above support at least two DID methods with open specifications
+    (i.e., accessible to all for implementaton and deployment) that is either at a CR snapshot level at the W3C (or a level with equivalent vetting and patent grants at another standard body) or has a large user community actively relying on that particular method.
+    It is also expected that each pair of the independant implementations mentioned above support at least one common DID method with an open specification.</p>
 
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
 


### PR DESCRIPTION
This PR reflects a change originally proposed by @jyasskin at https://github.com/w3c/charter-drafts/pull/448#discussion_r1410831656 .

> This should set a more specific bar than just "open specification". @cwilso and I suggested over [email](https://lists.w3.org/Archives/Public/public-did-wg/2023Nov/0017.html) that it be something like

@jandrieu [responded](https://github.com/w3c/charter-drafts/pull/448#discussion_r1410881587):

> We would oppose this.
>
> None of the DID methods are at that level of maturity.
>
> However, I agree that some further definition of "open" might be useful.
