### PR TITLE
Add AT-Driver to BTT Charter

### DIFF
--- a/2024/btt-wg.html
+++ b/2024/btt-wg.html
@@ -189,7 +189,7 @@
             </dd>
             <dt id="at-driver" class="spec"><a href="https://w3c.github.io/at-driver/">AT-Driver</a></dt>
             <dd>
-              <p>AT-Driver is a remote control interface that enables control of user agents using bidirectional communication mechanisms. It provides a platform- and language-neutral wire protocol as a way for out-of-process programs to remotely instruct the behavior of assitive technologies, spesifically screen-readers.</p>
+              <p>AT-Driver is a remote control interface that enables control of user agents using bidirectional communication mechanisms. It provides a platform- and language-neutral wire protocol as a way for out-of-process programs to instruct assistive technologies e.g. screen-readers.</p>
             </dd>
           </dl>
         </section>

--- a/2024/btt-wg.html
+++ b/2024/btt-wg.html
@@ -284,6 +284,7 @@
         <ul>
           <li><a href="https://github.com/w3c/webdriver">WebDriver spec repo</a>
           <li><a href="https://github.com/w3c/webdriver-bidi">WebDriver BiDi spec repo</a>
+          <li><a href="https://github.com/w3c/at-driver">AT-Driver spec repo</a>
         </ul>
         <p>The public is invited to review, discuss and contribute to this work.</p>
         <p>
@@ -490,6 +491,7 @@
                   2023‑08‑10
                 </td>
                 <td>WebDriver BiDi deliverable added.<br>
+                  AT-Driver deliverable added.<br>
                 New Patent Policy 2020.
                 </td>
               </tr>

--- a/2024/btt-wg.html
+++ b/2024/btt-wg.html
@@ -189,7 +189,7 @@
             </dd>
             <dt id="at-driver" class="spec"><a href="https://w3c.github.io/at-driver/">AT-Driver</a></dt>
             <dd>
-              <p>AT-Driver is a remote control interface that enables control of user agents using bidirectional communication mechanisms. It provides a platform- and language-neutral wire protocol as a way for out-of-process programs to instruct assistive technologies e.g. screen-readers.</p>
+              <p>AT Driver defines a protocol for introspection and remote control of assistive technology (AT) such as screen readers, using a bidirectional communication channel.</p>
             </dd>
           </dl>
         </section>

--- a/2024/btt-wg.html
+++ b/2024/btt-wg.html
@@ -99,7 +99,7 @@
             <td>
               See the <a href="https://www.w3.org/groups/wg/browser-tools-testing//charters/">group status page</a> and <a href="#history">detailed change history</a>.
             </td>
-          </tr>		
+          </tr>
           <tr id="Duration">
             <th>
               Start date
@@ -186,6 +186,10 @@
             <dt id="webdriver-bidi" class="spec"><a href="https://w3c.github.io/webdriver-bidi/">WebDriver Bidirectional Protocol</a></dt>
             <dd>
               <p>The WebDriver Bidirectional Protocol extends WebDriver by introducing a bidirectional communication mechanism; in place of the strict command/response format of WebDriver, that bidirectional communication mechanism permits events to stream from the user agent to the controlling software, better matching the evented nature of the browser DOM.</p>
+            </dd>
+            <dt id="at-driver" class="spec"><a href="https://w3c.github.io/at-driver/">AT-Driver</a></dt>
+            <dd>
+              <p>AT-Driver is a remote control interface that enables control of user agents using bidirectional communication mechanisms. It provides a platform- and language-neutral wire protocol as a way for out-of-process programs to remotely instruct the behavior of assitive technologies, spesifically screen-readers.</p>
             </dd>
           </dl>
         </section>

--- a/2024/btt-wg.html
+++ b/2024/btt-wg.html
@@ -491,7 +491,7 @@
                   2023‑08‑10
                 </td>
                 <td>WebDriver BiDi deliverable added.<br>
-                  AT-Driver deliverable added.<br>
+                  AT Driver deliverable added.<br>
                 New Patent Policy 2020.
                 </td>
               </tr>


### PR DESCRIPTION
Adding the [AT-Driver spec](https://w3c.github.io/at-driver/) to the BTT Charter for 2024.