### PR TITLE
[template] Add a reminder to keep the GH link

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -84,7 +84,8 @@
         <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
       </div>
 
-         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      <!-- delete the GH link after AC review completed -->
+      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
       on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
 
     Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.


### PR DESCRIPTION
I deleted the GH link when I published the Privacy WG charter and it should have been kept until the charter got reviewed  by the AC.
