### PR TITLE
[did/wg] Re-introduce wording about seeking consensus

### DIFF
--- a/2023/did-wg.html
+++ b/2023/did-wg.html
@@ -80,7 +80,7 @@ The <strong>mission</strong> of the
 <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a>
 is two-fold. First, it will maintain the <a href="https://www.w3.org/TR/did-core/">Decentralized Identifiers (DIDs)</a>
 specification and related Working Group Notes.
-Second, it will define common requirements, algorithms, architectural options, and various considerations for the DID resolution and DID URL dereferencing processes.
+Second, it will seek consensus around the best way to achieve effective interoperability through common requirements, algorithms, architectural options, and various considerations for the DID resolution and DID URL dereferencing processes.
       </p>
 
       <div class="noprint">


### PR DESCRIPTION
This PR addresses the first part of https://lists.w3.org/Archives/Member/member-charters-review/2023Dec/0003.html .

I don't think that re-introducing this text is controversial, because its removal (in aacf57d) was not meant, in itself, to address any specific objection.