### PR TITLE
[fedid] potential typo

### DIFF
--- a/2024/wg-fedid.html
+++ b/2024/wg-fedid.html
@@ -159,7 +159,7 @@
         The group would like to: 
       </p>
       <ul>
-        <li>Enable federated identity while adhering to <a href='https://www.w3.org/TR/privacy-principles/'>privacy principles</a> despite the <a href='https://www.w3.org/2001/tag/doc/web-without-3p-cookies/'>third-party cookies</a>, a cornerstone of such operations, with the FedCM AP</li>
+        <li>Enable federated identity while adhering to <a href='https://www.w3.org/TR/privacy-principles/'>privacy principles</a> despite the <a href='https://www.w3.org/2001/tag/doc/web-without-3p-cookies/'>third-party cookies</a>, a cornerstone of such operations, with the FedCM API.</li>
         <li>Enable privacy-preserving invocation of a wallet without <a href="https://github.com/WICG/digital-identities/blob/main/custom-schemes.md">custom schemes</a>, which have <a href="https://github.com/WICG/digital-identities/blob/main/custom-schemes.md#can-wallets-reliably-determine-their-invoker">security</a>, <a href="https://github.com/WICG/digital-identities/blob/main/custom-schemes.md#what-are-the-privacy-implications-of-a-wallet-accepting-custom-schemes">privacy</a>, and <a href="https://github.com/WICG/digital-identities/blob/main/custom-schemes.md#user-experience-concerns">user experience implications</a> and cannot reliably or securely work in cross-device scenarios, with the Digital Credentials API.</li>
       </ul>
     </div>


### PR DESCRIPTION
this should be `API`.