### PR TITLE
[template] Adds a Tentative Deliverables section

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -211,7 +211,7 @@
           </h3>
           <p>Depending on the incubation progress, interest from multiple implementers, and the consensus
             of the Group participants, the Working Group may adopt the following documents
-            for the following documents:</p>
+             as Rec-track specifications:</p>
           <dl>
             <dt id="web-incubated-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
             <dd>

--- a/charter-template.html
+++ b/charter-template.html
@@ -204,6 +204,24 @@
 
         </section>
 
+        <section id="incubation">
+          <!-- If no incubation or not a Working Group, delete the section. -->
+          <h3>
+            Tentative Deliverables
+          </h3>
+          <p>Depending on the incubation progress, interest from multiple implementers, and the consensus
+            of the Group participants, the Working Group may also produce Recommendation-track specifications
+            for the following documents:</p>
+          <dl>
+            <dt id="web-incubated-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
+            <dd>
+              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
+              <p class="draft-status"><b>Draft state:</b>
+                Proposal in <a href=""><i class="todo">[other name]</i> Community Group</a></p>
+            </dd>
+          </dl>
+        </section>
+
         <section id="ig-other-deliverables">
           <h3>
             Other Deliverables

--- a/charter-template.html
+++ b/charter-template.html
@@ -210,7 +210,7 @@
             Tentative Deliverables
           </h3>
           <p>Depending on the incubation progress, interest from multiple implementers, and the consensus
-            of the Group participants, the Working Group may also produce Recommendation-track specifications
+            of the Group participants, the Working Group may adopt the following documents
             for the following documents:</p>
           <dl>
             <dt id="web-incubated-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>


### PR DESCRIPTION
This adds support in the charter template to list specifications that are being incubated but may get adopted later without rechartering.
