### PR TITLE
[cg/swag] Update SoW/OOS

### DIFF
--- a/2024/swag-cg.html
+++ b/2024/swag-cg.html
@@ -74,15 +74,19 @@
           <li>Theory, Attacks, Practices and Tools.</li>
         </ul>
       </li>
-      <li>Develop a set of security best practices for web developers and product owners. This includes:
+      <li>Develop a set of security best practices for web developers, product owners, and open source package managers. This includes:
         <ul>
           <li>Framework/Library secure development best practices.</li>
           <li>WebAssembly secure development best practices.</li>
-          <li>Integrating software supply chain approaches to ease security assessments.</li>
+          <li>Secure build process best practices.</li>
+          <li>Integration of Security in the Web Development lifecycle best practices.</li>
+          <li>Responsible and Secure Dependency Checking best practice.</li>
+          <li>Secure software supply chain management best practice, to ease security assessments.</li>
           <li>Formulating end-user stories related to security to inform groups developing technical APIs and policymakers developing regulations.</li>
         </ul>
       </li>
-      <li>    Coordinate actions with external organizations:
+      <li>Incubate Web Developer's Security-related ideas and needs, and then provide them as input to the various W3C groups.</li>
+      <li>Coordinate actions with external organizations:
         <ul>
           <li>It could include one or more joint deliverables.</li>
           <li>It could include joint communication.</li>
@@ -92,10 +96,6 @@
       </li>
       <li>Review possible directions to sanitize web APIs in isolated contexts (compartments).</li>
       <li>Track specifications and vendor implementations related to security.</li>
-      <li><span class="remove">...</span>What should build tools do to assure that nobody is hijacking the process?</li>
-      <li><span class="remove">...</span>helping to bring security best practices into the default developer lifecycle for web developers</li>
-      <li><span class="remove">...</span>helping package managers become more responsible about their dependency checking</li>
-      <li><span class="remove">...</span>work with Security IG to help develop security principles that can be used in wide reviews</li>
     </ul>
     <h3 id="out-of-scope">
       Out of Scope
@@ -104,7 +104,7 @@
       The development of normative standards and technical specifications is not in the scope of the Community Group.
     </p>
     <p>
-      This group does not perform horizontal reviews for security at W3C; that is the responsibility of the Security Interest Group (SING).
+      This group does not perform horizontal reviews for security at W3C.
     </p>
 
     <h2 id="deliverables">


### PR DESCRIPTION
- Scope: added other deliverables to the list and defined a point the more generic collaboration with W3C group to bring Web Developers' point of view (e.g. in principles).
- Out-Of-Scope: removed SING since it hasn't been opened yet.