### PR TITLE
[ig/security] Update Scope and Deliverables

### DIFF
--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -160,7 +160,8 @@
 
       <section id="scope" class="scope">
         <h2>Scope</h2>
-        <p>The Security Interest Group (SING) develops and documents guidelines, patterns, processes, and best practices for addressing security considerations in Web standards.</p>
+        <p>The Security Interest Group (SING) develops and documents guidelines, patterns, processes, and best practices for addressing security issues in Web standards.</p>
+	<p>SING supports, promotes, and structures the threat modeling for web standards and technologies. This approach can be used, along with other groups, for threats of different types such as security, privacy, and harm. Threat modeling is a joint activity with groups developing technology or other documentation and threat experts. It can be used to get an understanding of the impact of the technology and guide its development, as well as to write considerations.</p>
         <p>SING provides "<a href="https://www.w3.org/Guide/documentreview/">horizontal review</a>", offering groups on-request guidance on security issues and mitigations specific to their technologies. SING aims to offer this review as early in the technology development lifecycle as requested, observing that early feedback is often more helpful. SING may also seek out technologies that benefit from earlier security reviews and conduct such reviews on its initiative.</p>
         <p>SING incubates standards work on security issues by collecting requirements, prototyping, and/or initiating the work within the IG and recommending that the W3C move the work into other groups when appropriate.</p>
         <p>SING may recommend mitigations for security issues in existing features of the Web platform, up to and including their deprecation.</p>
@@ -169,7 +170,7 @@
 
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
-            <p>The following features are out of scope, and will not be addressed by this Interest group.</p>
+            <p>The following features are out of scope and will not be addressed by this Interest group.</p>
             <p>The technical development of standards is not in the scope of the Interest Group. Identified Recommendation Track opportunities will be handed over to appropriate W3C groups if such a group exists or within a dedicated Community Group or Business Group when incubation is needed.</p>
         </section>
       </section>
@@ -179,9 +180,10 @@
         </h2>
 
         <p>Updated document status is available on the <a href="https://www.w3.org/groups/ig/@@/publications">group publication status page</a>.</p>
-
-        <p>In conjunction with W3C's <a href="https://www.w3.org/2001/tag/">Technical Architecture Group (TAG)</a> and <a href="https://www.w3.org/groups/ig/privacy/">PING</a>, SING maintains the <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire for Security and Privacy</a>.</p>
-        <p>SING may publish other documents consistent with the above scope, such as analyses of security issues, prototype specifications, security principles, threat models, and guidelines for standards.</p>
+        <p><a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire for Security and Privacy</a>: In joint with W3C's <a href="https://www.w3.org/2001/tag/">Technical Architecture Group (TAG)</a> and <a href="https://www.w3.org/groups/ig/privacy/">PING</a>, with a specific focus on Security aspect.</p>
+	<p>Threat Modeling guide: in joint with relevant groups such as TAG, PING, and the <a href="https://www.w3.org/groups/cg/tmcg/">Threat Modeling Community Group</a>, a guide that contains both generic threat modeling elements to facilitate activities along with groups creating technology, and also to understand threats of different types.</p>
+	<p><a href="https://github.com/w3c/security-request/issues/new/choose">Security Request Issue template</a>: to facilitate the request of Security Reivews.</p>
+	<p>SING may publish other documents consistent with the above scope, such as analyses of security issues, prototype specifications, security principles, threat models, and guidelines for standards.</p>
 
         </section>
 


### PR DESCRIPTION
- Added in the Scope a specific point of a generic Threat Modeling approach that can be shared with other groups
- Added the Threat Modeling guide as a deliverable, and also the issue template and rephrased the questionnaire point