### PR TITLE
Add GeoSPARQL & CRS Ont to NormSpecs

### DIFF
--- a/2024/sdw-wg.html
+++ b/2024/sdw-wg.html
@@ -267,11 +267,13 @@
             <li class=spec id=10811> <a href="https://www.ogc.org/standard/geosparql/">OGC GeoSPARQL - A
                 Geographic Query Language for RDF Data</a>
               <ul>
-                <li class=draft-status>Draft state: Not Approved
-
-                <li>Latest Publication: <a href="https://docs.ogc.org/is/22-047r1/22-047r1.html">2024-01-29</a> (v1.1)</li>
+                <li class=draft-status>Draft state: Not Approved</li>
 
                 <li>Expected completion: Q4 2025 (v1.3)</li>
+
+                <li>OGC SWG: GeoSPARQL SWG <a href="https://portal.ogc.org/index.php?m=projects&a=view&project_id=50">Geosemantics DWG</a></li>
+
+                <li>Latest Publication: <a href="https://docs.ogc.org/is/22-047r1/22-047r1.html">2024-01-29</a> (v1.1)</li>
 
                 <li>Abstract:
                   <p>GeoSPARQL contains a small spatial domain OWL ontology that allow literal representations of
@@ -291,11 +293,13 @@
             <!-- CRS Ont -->
             <li class=spec id=10812> <a href="https://github.com/opengeospatial/ontology-crs">Coordinate Reference System Ontology</a>
               <ul>
-                <li class=draft-status>Draft state: Not Approved
-
-                <li>Latest Publication: not yet published</li>
+                <li class=draft-status>Draft state: Not Approved</li>
 
                 <li>Expected completion: Q1 2025</li>
+
+                <li>OGC SWG: GeoSPARQL SWG <a href="https://portal.ogc.org/index.php?m=projects&a=view&project_id=50">Geosemantics DWG</a></li>
+
+                <li>Latest Publication: not yet published</li>
 
                 <li>Abstract:
                   <p>An ontology for coordinate reference systems (CRS)</p>

--- a/2024/sdw-wg.html
+++ b/2024/sdw-wg.html
@@ -189,6 +189,10 @@
         <li>Work with OGC Standard Working Groups to jointly develop, maintain and promote geospatial Web standards and geospatial
           profiles of more general Web standards.</li>
 
+        <li>Co-publish the next version of GeoSPARQL as a joint W3C/OGC standard</li>
+
+        <li>Co-publish the OGC's CRS Ontology as a joint W3C/OGC standard</li>
+
         <li>Maintain a list of OGC specifications and resources describing current practices in order to publicise these
           to the W3C audience.</li>
 
@@ -219,124 +223,165 @@
       <section id=normative>
         <h3>Normative Specifications</h3>
 
-        <p>The Working Group will deliver the following W3C
-          normative specifications:
+        <section id="included">
+          <p>The Working Group will deliver the following W3C
+            normative specifications:
 
-        <ul>
-          <li class=spec id=6379> <a href="https://www.w3.org/TR/vocab-ssn/" rel=versionof>Semantic Sensor Network
-              Ontology</a> – new edition
-            <ul>
-              <li class=draft-status>Draft state: Adopted
+          <ul>
+            <!-- SSN -->
+            <li class=spec id=6379> <a href="https://www.w3.org/TR/vocab-ssn/" rel=versionof>Semantic Sensor Network
+                Ontology</a> – new edition
+              <ul>
+                <li class=draft-status>Draft state: Adopted
 
-              <li class=milestone>Expected completion: Q4 2024
+                <li class=milestone>Expected completion: Q4 2024
 
-              <li>OGC SWG: <a href="https://portal.ogc.org/?m=projects&a=view&project_id=292">Observations, Measurements, and Samples SWG</a>
+                <li>OGC SWG: <a href="https://portal.ogc.org/?m=projects&a=view&project_id=292">Observations, Measurements, and Samples SWG</a>
 
-              <li>Latest publication: <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/">2017-10-19</a>
+                <li>Latest publication: <a href="https://www.w3.org/TR/2017/REC-vocab-ssn-20171019/">2017-10-19</a>
 
-              <li>Abstract:
-                <p>The Semantic Sensor Network (SSN) ontology is an
-                  RDFS/OWL ontology for describing observations made
-                  by sensors implementing specified procedures, the
-                  studied features of interest and the observed
-                  properties, along with samples used in the
-                  observations and the sampling activities that
-                  created them, as well as actuations which follow a
-                  similar semantics and data structure.
+                <li>Abstract:
+                  <p>The Semantic Sensor Network (SSN) ontology is an
+                    RDFS/OWL ontology for describing observations made
+                    by sensors implementing specified procedures, the
+                    studied features of interest and the observed
+                    properties, along with samples used in the
+                    observations and the sampling activities that
+                    created them, as well as actuations which follow a
+                    similar semantics and data structure.
 
-                <p>The SOSA vocabulary (Sensors, Observations,
-                  Samples and Actuations) contains the core terms and
-                  definitions from SSN, packaged for use in general
-                  applications.
+                  <p>The SOSA vocabulary (Sensors, Observations,
+                    Samples and Actuations) contains the core terms and
+                    definitions from SSN, packaged for use in general
+                    applications.
 
-                <p>Some extension modules are included in the
-                  recommendation.
+                  <p>Some extension modules are included in the
+                    recommendation.
 
-                <p>Alignments with some related ontologies and data
-                  models are included in the recommendation.
-            </ul>
-        </ul>
+                  <p>Alignments with some related ontologies and data
+                    models are included in the recommendation.
+              </ul>
+            </li>
 
-        <p>The following existing specifications are potentially in scope for maintenance:
+            <!-- GeoSPARQL -->
+            <li class=spec id=10811> <a href="https://www.ogc.org/standard/geosparql/">OGC GeoSPARQL - A
+                Geographic Query Language for RDF Data</a>
+              <ul>
+                <li class=draft-status>Draft state: Not Approved
 
-        <ul>
-          <li class=spec id=10810> <a href="https://www.ogc.org/standard/geosparql/" rel=versionof>OGC GeoSPARQL - A
-              Geographic Query Language for RDF Data</a>
-            <ul>
-              <li class=draft-status>Draft state: Approved
+                <li>Latest Publication: <a href="https://docs.ogc.org/is/22-047r1/22-047r1.html">2024-01-29</a> (v1.1)</li>
 
-              <li>Latest Publication: <a href="https://docs.ogc.org/is/22-047r1/22-047r1.html">2024-01-29</a>
+                <li>Expected completion: Q4 2025 (v1.3)</li>
 
-            </ul>
+                <li>Abstract:
+                  <p>GeoSPARQL contains a small spatial domain OWL ontology that allow literal representations of
+                    geometries to be associated with spatial features and for features to be associated with other
+                    features using spatial relations.</p>
 
-          <li class=spec id=10810> <a href="https://www.w3.org/TR/owl-time/" rel=versionof>Time Ontology in OWL</a>
-            <ul>
-              <li class=draft-status>Draft state: Adopted
+                  <p>GeoSPARQL also contains SPARQL extension function definitions that can be used to calculate
+                    relations between spatial objects.</p>
 
-              <li>Latest Publication: <a href="https://www.w3.org/TR/2022/CRD-owl-time-20221115/">2022-11-15</a>
+                  <p>Several other supporting assets are also contained within GeoSPARQL such as vocabularies of
+                    Simple Feature types and data validators.</p>
+                </li>
 
-              <li>Exclusion Draft: <a
-                  href="https://www.w3.org/TR/2017/CR-owl-time-20170606/">https://www.w3.org/TR/2017/CR-owl-time-20170606/</a>
+              </ul>
+            </li>
 
-              <li>Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2017Jun/0003.html">Call for
-                  Exclusion</a> on 2017-06-06 ended on
-                2017-08-05
+            <!-- CRS Ont -->
+            <li class=spec id=10812> <a href="https://github.com/opengeospatial/ontology-crs">Coordinate Reference System Ontology</a>
+              <ul>
+                <li class=draft-status>Draft state: Not Approved
 
-              <li>Produced under Working Group Charter: <a
-                  href="https://www.w3.org/2015/spatial/charter">http://www.w3.org/2015/spatial/charter</a>
-            </ul>
+                <li>Latest Publication: not yet published</li>
 
-          <li class=spec id=5693> <a href="https://www.w3.org/TR/sdw-ucr/" rel=versionof>Spatial Data on the Web Use
-              Cases &amp; Requirements</a>
-            <ul>
-              <li>Draft state: Adopted
+                <li>Expected completion: Q1 2025</li>
 
-              <li>Latest publication: <a href="https://www.w3.org/TR/2016/NOTE-sdw-ucr-20161025/">2016-10-25</a>
-            </ul>
+                <li>Abstract:
+                  <p>An ontology for coordinate reference systems (CRS)</p>
+                </li>
 
-          <li class=spec id=6198> <a href="https://www.w3.org/TR/covjson-overview/" rel=versionof>Overview of the
-              CoverageJSON format</a>
-            <ul>
-              <li>Draft state: Adopted
+              </ul>
+            </li>
 
-              <li>Latest publication: <a
-                  href="https://www.w3.org/TR/2017/NOTE-covjson-overview-20170711/">2017-07-11</a>
-            </ul>
+          </ul>
+        </section>
 
-          <li class=spec id=6347> <a href="https://www.w3.org/TR/qb4st/" rel=versionof>QB4ST:
-              RDF Data Cube extensions for spatio-temporal
-              components</a>
-            <ul>
-              <li>Draft state: Adopted
+        <section id="potential">
+          <p>The following existing specifications are potentially in scope for maintenance:
 
-              <li>Latest publication: <a href="https://www.w3.org/TR/2017/NOTE-qb4st-20170928/">2017-09-28</a>
-            </ul>
+          <ul>
+            <li class=spec id=10810> <a href="https://www.w3.org/TR/owl-time/" rel=versionof>Time Ontology in OWL</a>
+              <ul>
+                <li class=draft-status>Draft state: Adopted
 
-          <li class=spec id=6348> <a href="https://www.w3.org/TR/eo-qb/" rel=versionof>Publishing and Using Earth
-              Observation Data with the RDF
-              Data Cube and the Discrete Global Grid System</a>
-            <ul>
-              <li>Draft state: Adopted
+                <li>Latest Publication: <a href="https://www.w3.org/TR/2022/CRD-owl-time-20221115/">2022-11-15</a>
 
-              <li>Latest publication: <a href="https://www.w3.org/TR/2017/NOTE-eo-qb-20170928/">2017-09-28</a>
-            </ul>
+                <li>Exclusion Draft: <a
+                    href="https://www.w3.org/TR/2017/CR-owl-time-20170606/">https://www.w3.org/TR/2017/CR-owl-time-20170606/</a>
 
-          <li class=spec id=12390> <a href="https://www.w3.org/TR/sdw-bp/" rel=versionof>Spatial Data on the Web Best
-              Practices</a>
-            <ul>
-              <li>Draft state: Adopted
+                <li>Associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2017Jun/0003.html">Call for
+                    Exclusion</a> on 2017-06-06 ended on
+                  2017-08-05
 
-              <li>Latest publication: <a href="https://www.w3.org/TR/2023/DNOTE-sdw-bp-20230919/">2023-09-19</a>
-            </ul>
+                <li>Produced under Working Group Charter: <a
+                    href="https://www.w3.org/2015/spatial/charter">http://www.w3.org/2015/spatial/charter</a>
+              </ul>
 
-          <li class=spec id=12391> <a href="https://www.w3.org/TR/webvmt/" rel=versionof>WebVMT: The Web Video Map
-              Tracks Format</a>
-            <ul>
-              <li>Draft state: Adopted
+            <li class=spec id=5693> <a href="https://www.w3.org/TR/sdw-ucr/" rel=versionof>Spatial Data on the Web Use
+                Cases &amp; Requirements</a>
+              <ul>
+                <li>Draft state: Adopted
 
-              <li>Latest publication: <a href="https://www.w3.org/TR/2023/NOTE-webvmt-20230919/">2023-09-19</a>
-            </ul>
-        </ul>
+                <li>Latest publication: <a href="https://www.w3.org/TR/2016/NOTE-sdw-ucr-20161025/">2016-10-25</a>
+              </ul>
+
+            <li class=spec id=6198> <a href="https://www.w3.org/TR/covjson-overview/" rel=versionof>Overview of the
+                CoverageJSON format</a>
+              <ul>
+                <li>Draft state: Adopted
+
+                <li>Latest publication: <a
+                    href="https://www.w3.org/TR/2017/NOTE-covjson-overview-20170711/">2017-07-11</a>
+              </ul>
+
+            <li class=spec id=6347> <a href="https://www.w3.org/TR/qb4st/" rel=versionof>QB4ST:
+                RDF Data Cube extensions for spatio-temporal
+                components</a>
+              <ul>
+                <li>Draft state: Adopted
+
+                <li>Latest publication: <a href="https://www.w3.org/TR/2017/NOTE-qb4st-20170928/">2017-09-28</a>
+              </ul>
+
+            <li class=spec id=6348> <a href="https://www.w3.org/TR/eo-qb/" rel=versionof>Publishing and Using Earth
+                Observation Data with the RDF
+                Data Cube and the Discrete Global Grid System</a>
+              <ul>
+                <li>Draft state: Adopted
+
+                <li>Latest publication: <a href="https://www.w3.org/TR/2017/NOTE-eo-qb-20170928/">2017-09-28</a>
+              </ul>
+
+            <li class=spec id=12390> <a href="https://www.w3.org/TR/sdw-bp/" rel=versionof>Spatial Data on the Web Best
+                Practices</a>
+              <ul>
+                <li>Draft state: Adopted
+
+                <li>Latest publication: <a href="https://www.w3.org/TR/2023/DNOTE-sdw-bp-20230919/">2023-09-19</a>
+              </ul>
+
+            <li class=spec id=12391> <a href="https://www.w3.org/TR/webvmt/" rel=versionof>WebVMT: The Web Video Map
+                Tracks Format</a>
+              <ul>
+                <li>Draft state: Adopted
+
+                <li>Latest publication: <a href="https://www.w3.org/TR/2023/NOTE-webvmt-20230919/">2023-09-19</a>
+              </ul>
+
+          </ul>
+        </section>
+
       </section>
 
       <section id=ig-other-deliverables>


### PR DESCRIPTION
This addition will add the OGC's GeoSemantics DWG GeoSPARQL 1.3 and CRS Ontology to the scope of the SDWWG's normative specs.

The GeoSemantics DWG believes that co-publication would:

1. achieve wider standardisation
    - there is no W3C equivalent to GeoSPARQL and W3C spec use GeoSPARL, so let's make it more official
    - GeoSPARQL is already proposed as an ISO standard so if we do this, we could have the same standard ratified by 3 
(the main?) spatial data standard bodies
    - there is no W3C equivalent to the CRS Ontology yet it is a W3C-style model (ontology)
2. synchronised SDWWG & GeoSemantics DWG work
    - the SDWWG is working on things around GeoSPARQL now we would like to ensure their work and GeoSemantics' is as aligned as possible, not in parallel
3. be supported by the OG & SWG staff
    - the OGC's Naming Authority staff and proposed SDW WG chairs
4. be at the right time
    - if we want this done done, now is the time as the SDW WG charter is currently being worked on

The GeoSPARQL Standards Working Group and the CRS Ontology Standards Working Group at the OGC endorse these additions.

The rendered HTML version of the Draft Charter with these additions is visible at: 

* https://raw.githack.com/Kurrawong/w3c-charter-drafts/geosparql-sdwwg/2024/sdw-wg.html