### PR TITLE
[ig/security] from Process CG to AB

### DIFF
--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -162,7 +162,7 @@
         <p>SING provides "<a href="https://www.w3.org/Guide/documentreview/">horizontal review</a>", offering groups on-request guidance on security issues and mitigations specific to their technologies. SING aims to offer this review as early in the technology development lifecycle as requested, observing that early feedback is often more helpful. SING may also seek out technologies that benefit from earlier security reviews and conduct such reviews on its initiative.</p>
         <p>SING incubates standards work on security issues by collecting requirements, prototyping, and/or initiating the work within the IG and recommending that the W3C move the work into other groups when appropriate.</p>
         <p>SING may recommend mitigations for security issues in existing features of the Web platform, up to and including their deprecation.</p>
-        <p>SING may provide input to the <a href="https://www.w3.org/community/w3process/">W3C Process Community Group</a> on process changes that will improve security in Web standards, e.g., by establishing particular requirements or threat models for identifying and mitigating security issues in W3C Recommendations.</p>
+        <p>SING may provide input to the <a href="https://www.w3.org/groups/other/ab/">Advisory Board</a> on process changes that will improve security in Web standards, e.g., by establishing particular requirements or threat models for identifying and mitigating security issues in W3C Recommendations.</p>
         <p>SING may recommend to the <a href="https://www.w3.org/groups/other/ac/">W3C Advisory Committee</a> and the <a href="https://www.w3.org/groups/other/tag/">W3C TAG</a> regarding the security impact of proposed standards.</p>
 
         <section id="section-out-of-scope">


### PR DESCRIPTION
For the W3C process, refer to AB directly instead of Process CG, as suggested by @frivoal

References:
- https://github.com/w3c/charter-drafts/issues/547
- https://lists.w3.org/Archives/Member/w3c-ac-forum/2024JulSep/0065.html