### PR TITLE
[template] Avoid mentioning PR directly

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -254,8 +254,8 @@
 	  <h2>Success Criteria</h2>
 
     <!-- Testing and interop -->
-	  <p><span class='todo'>Remove this clause if the Group does not intend to move to REC:</span> In order to advance to
-		  <a href="https://www.w3.org/policies/process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have
+	  <p><span class='todo'>Remove this clause if the Group does not intend to move to REC:</span> In order to advance beyond
+		  <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">Candidate Recommendation</a>, each normative specification is expected to have
 		  <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable
 			  implementations</a> of every feature defined in the specification, where
 interoperability can be verified by passing open test suites.</p>


### PR DESCRIPTION
There are proposed changes in the Process about simplifying the REC track that if adopted would result in Proposed Recommendation being retired as a maturity stage. The requirements to exit CR would remain the same though.

This rephrasing recasts the criteria expect in order to enter PR in terms of exiting CR instead. This is strictly equivalent, but avoids mentioning PR by name, making this language more forward compatible with this potential upcoming Process change.