### PR TITLE
[ig/security] Add a concrete threat model for the Web to the deliverables.

### DIFF
--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -98,7 +98,7 @@
             <td>
               See the <a href="https://www.w3.org/groups/ig/@@/charters">group status page</A> and <a href="#history">detailed change history</a>.
             </td>
-          </tr>		
+          </tr>
           <tr id="Duration">
             <th>
               Start date
@@ -186,6 +186,24 @@
                 In joint with W3C's <a href="https://www.w3.org/2001/tag/">Technical Architecture Group (TAG)</a> and <a href="https://www.w3.org/groups/ig/privacy/">PING</a>, with a specific focus on Security aspect.
               </p>
             </dd>
+            <dt id="TM" class="spec">
+              A Threat Model for the Web
+            </dt>
+            <dd>
+              <p>
+                A description of the Web's threat model, which new specifications need to maintain.
+                This threat model may include goals that have not yet been achieved across the whole
+                web platform, but which will still be enforced in reviews of new and changed
+                specifications. This will be developed with input from other relevant groups such as
+                the TAG, PING, WebAppSec, and the <a
+                href="https://www.w3.org/groups/cg/tmcg/">Threat Modeling Community Group</a>.
+              </p>
+              <p><b>Potential input documents:</b></p>
+              <ul>
+                <li><a href="https://chromium.googlesource.com/chromium/src/+/master/docs/security/web-platform-security-guidelines.md">Chromium Web Platform Security guidelines</a></li>
+                <li>The <a href="https://xsleaks.dev/">XS-Leaks Wiki</a></li>
+              <ul>
+            </dd>
             <dt id="TMG" class="spec">
               Threat Modeling guide
             </dt>
@@ -220,7 +238,7 @@
             <li>Primer or Best Practice documents to support web security when designing standards and applications.</li>
           </ul>
         </section>
- 
+
 	<section id="success-criteria">
 	  <h2>Success Criteria</h2>
         <ul>


### PR DESCRIPTION
This goes along with [Google's comment](https://lists.w3.org/Archives/Public/public-review-comments/2024Sep/0004.html) in the charter's AC review.