### PR TITLE
[wg/fedid] Coordination: add SocialCG/IndieAuth, drop all rel=nofollow

### DIFF
--- a/2024/wg-fedid.html
+++ b/2024/wg-fedid.html
@@ -84,8 +84,8 @@
 
     <!-- delete the GH link after AC review completed -->
     <p style="padding: 0.5ex; border: 1px solid green">
-      This draft charter is available on <a href="https://github.com/w3c/charter-drafts/" rel="nofollow">GitHub</a>.
-      Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues/new?title=%5Bwg/fedid%5D" rel="nofollow">issues</a> or see the ones that <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue+is%3Aopen+%5Bwg%2Ffedid%5D" rel="nofollow">are open</a>.
+      This draft charter is available on <a href="https://github.com/w3c/charter-drafts/">GitHub</a>.
+      Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues/new?title=%5Bwg/fedid%5D">issues</a> or see the ones that <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue+is%3Aopen+%5Bwg%2Ffedid%5D">are open</a>.
     </p>
 
 
@@ -176,8 +176,8 @@
         This group develops new mechanisms that define how information is passed by the user agent between the different entities to facilitate federated and digital identities:
       </p>
       <ul>
-        <li>Enabling a Federated Identity Model while adhering to <a href="https://www.w3.org/TR/privacy-principles/" rel="nofollow">privacy principles</a> despite the <a href="https://www.w3.org/2001/tag/doc/web-without-3p-cookies/" rel="nofollow">deprecation of third-party cookies</a>, a cornerstone of such operations.</li>
-        <li>Enabling a Decentralized Identity Model by invoking a wallet, without <a href="https://github.com/WICG/digital-identities/blob/main/custom-schemes.md" rel="nofollow">custom schemes</a> or privacy-invasive alternative identity and attribute verification systems.</li>
+        <li>Enabling a Federated Identity Model while adhering to <a href="https://www.w3.org/TR/privacy-principles/">privacy principles</a> despite the <a href="https://www.w3.org/2001/tag/doc/web-without-3p-cookies/">deprecation of third-party cookies</a>, a cornerstone of such operations.</li>
+        <li>Enabling a Decentralized Identity Model by invoking a wallet, without <a href="https://github.com/WICG/digital-identities/blob/main/custom-schemes.md">custom schemes</a> or privacy-invasive alternative identity and attribute verification systems.</li>
       </ul>
       <section id="section-out-of-scope">
         <h3 id="out-of-scope">Out of Scope</h3>
@@ -366,23 +366,25 @@
       <section>
         <h3 id="w3c-coordination">W3C Groups</h3>
         <dl>
-          <dt><a href="https://www.w3.org/WAI/APA/" rel="nofollow">Accessible Platform Architectures Working Group</a></dt>
+          <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
           <dd>The Accessible Platform Architectures Working Group seeks to ensure that accessibility is kept front of mind, as authentication timing and the reliance on short term memory are known and thorny topics for people with disabilities. Our group is expected to regularly coordinate with them for accessibility-related issues.</dd>
-          <dt><a href="https://www.w3.org/2019/did-wg/" rel="nofollow">Decentralized Identifier Working Group</a></dt>
+          <dt><a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a></dt>
           <dd>The Decentralized Identifier Working Group is the maintainer of Decentralized Identifiers, one of the core building blocks of Digital Identities. Our group is expected to communicate with them for Digital Identities related issues.</dd>
-          <dt><a href="https://www.w3.org/groups/cg/fed-id" rel="nofollow">Federated Identity Community Group</a></dt>
+          <dt><a href="https://www.w3.org/groups/cg/fed-id">Federated Identity Community Group</a></dt>
           <dd>The Federated Identity Community Group is to provide a forum focused on incubating web features that will both support federated identity and prevent untransparent, uncontrollable tracking of users across the web. Our group is expected to regularly coordinate with them to put in the standardization track incubated proposals.</dd>
-          <dt><a href="https://privacycg.github.io/" rel="nofollow">Privacy Community Group</a></dt>
+          <dt><a href="https://privacycg.github.io/">Privacy Community Group</a></dt>
           <dd>The Privacy Community Group is to incubate privacy-focused web features and APIs to improve user privacy on the web through enhanced browser behavior. Our group is expected to regularly coordinate with them for privacy-related issues.</dd>
-          <dt><a href="https://www.w3.org/Privacy/IG/" rel="nofollow">Privacy Interest Group</a></dt>
+          <dt><a href="https://www.w3.org/Privacy/IG/">Privacy Interest Group</a></dt>
           <dd>The Privacy Community Interest Group monitors ongoing privacy issues that affect the Web, investigates potential areas for new privacy work, and provides guidelines and advice for addressing privacy in standards development, including privacy considerations in specifications. Our group is expected to coordinate with them regularly on privacy-related issues.
           </dd>
-          <dt><a href="https://www.w3.org/2011/webappsec/" rel="nofollow">Web Application Security Working Group</a></dt>
+          <dt><a href="https://www.w3.org/wiki/SocialCG/">Social Web Community Group</a></dt>
+          <dd>The Social Web Community Group maintains errata for any specs published by the Social Web Working Group. Our group should coordinate with them for identity related topics that may overlap with the <a href="https://www.w3.org/TR/indieauth/">IndieAuth spec</a>.</dd>
+          <dt><a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a></dt>
           <dd>The Web Application Security Working Group develops mechanisms and best practices that improve the security of Web Applications. Our group is expected to coordinate with them for security-related issues.</dd>
-          <dt><a href="https://www.w3.org/groups/wg/vc/" rel="nofollow">Verifiable Credentials Working Group</a></dt>
+          <dt><a href="https://www.w3.org/groups/wg/vc/">Verifiable Credentials Working Group</a></dt>
           <dd>The Verifiable Credentials Working Group is the venue for standardizing the Data Model for Verifiable Credentials. Our group is expected to coordinate with them for format and protocol-related issues.
           </dd>
-          <dt><a href="https://www.w3.org/groups/wg/webauthn/" rel="nofollow">Web Authentication Working Group</a></dt>
+          <dt><a href="https://www.w3.org/groups/wg/webauthn/">Web Authentication Working Group</a></dt>
           <dd>The Web Authentication Working Group is to define a client-side API that provides strong authentication functionality to web applications. While we are not developing an authentication mechanism, our group is expected to coordinate with them to provide feedback on authentication-related issues.
           </dd>
         </dl>
@@ -390,21 +392,21 @@
       <section>
         <h3 id="external-coordination">External Organizations</h3>
         <dl>
-          <dt><a href="https://www.ietf.org" rel="nofollow">IETF</a></dt>
+          <dt><a href="https://www.ietf.org">IETF</a></dt>
           <dd>Coordinate with the IETF research groups and working groups, such as OAuth, for protocol components on which authentication and authorization features depend.</dd>
-          <dt><a href="https://openid.net" rel="nofollow">OIDF</a></dt>
+          <dt><a href="https://openid.net">OIDF</a></dt>
           <dd>Coordinate with the OpenID Foundation (OIDF) for authorization and credentials flows (i.e., OIDC, OpenID4VC).</dd>
-          <dt><a href="https://oasis-open.org" rel="nofollow">OASIS</a></dt>
+          <dt><a href="https://oasis-open.org">OASIS</a></dt>
           <dd>Coordinate with OASIS for authentication flows (i.e., SAML).</dd>
-          <dt><a href="https://refeds.org" rel="nofollow">REFEDS</a></dt>
+          <dt><a href="https://refeds.org">REFEDS</a></dt>
           <dd>Coordinate with REFEDS for multi-lateral federation best practices and a representative of the complex use cases of the research and education communities worldwide.</dd>
           <dt><a href="https://www.etsi.org/committee/esi">European Telecommunications Standards Institute - Electronic Signatures and Infrastructure Technical Committee</a> </dt>
-          <dd>Coordinate with ETSI for <a href="https://digital-strategy.ec.europa.eu/en/policies/discover-eidas" rel="nofollow">eIDAS</a>, which can use the deliverables of the Group.</dd>
-          <dt><a href="https://www.nist.gov/" rel="nofollow"> National Institute of Standards and Technology, U.S. Department of Commerce </a></dt>
+          <dd>Coordinate with ETSI for <a href="https://digital-strategy.ec.europa.eu/en/policies/discover-eidas">eIDAS</a>, which can use the deliverables of the Group.</dd>
+          <dt><a href="https://www.nist.gov/"> National Institute of Standards and Technology, U.S. Department of Commerce </a></dt>
           <dd>Coordinate with NIST for their guidelines on digital identity and implementations.</dd>
-          <dt><a href="https://www.iso.org/committee/45144.html" rel="nofollow">ISO/IEC JTC 1 SC17 WG4 and WG10</a></dt>
+          <dt><a href="https://www.iso.org/committee/45144.html">ISO/IEC JTC 1 SC17 WG4 and WG10</a></dt>
           <dd>Coordinate with ISO for their work on interfaces and protocols for security devices, vehicle driver licenses, and related digital identities (i.e., mdoc).</dd>
-          <dt><a href="https://openwallet.foundation/" rel="nofollow">OpenWallet Foundation</a></dt>
+          <dt><a href="https://openwallet.foundation/">OpenWallet Foundation</a></dt>
           <dd>Coordinate with OpenWallet Foundation for their work on the Open Wallet Ecosystem.</dd>
         </dl>
       </section>


### PR DESCRIPTION
Coordination / W3C Groups. Added Social Web Community Group in particular on identity topics that may overlap with the IndieAuth spec from that group / prior Social Web WG.

Also dropped all the rel="nofollow" attributes on links. 

We should not be using rel="nofollow" in W3C docs/charters etc. 

Certainly it makes no sense to do so on W3C to W3C links, nor even W3C to GitHub links. Also it seems rude to use rel="nofollow" on links to organizations and groups we expect to coordinate with. If they're good enough for us to coordinate with and link to, we should absolutely not be using rel="nofollow" (nevermind that any first party use of rel="nofollow" violates the intent of the rel-nofollow spec).