### PR TITLE
[wg/aria] update the scope of the ARIA WG for the ARIA in HTML spec

### DIFF
--- a/2024/aria-charter.html
+++ b/2024/aria-charter.html
@@ -186,8 +186,7 @@
           necessary</li>
         <li>For each ARIA specification developed by this Working Group, create a corresponding Accessibility API
           Mappings specification defining the correct exposure for each platform</li>
-        <li>Maintain a specification for mapping HTML elements and attributes to platform accessibility APIs, and a separate specification that defines author conformance requirements for setting ARIA attributes</li>
-        <li>For all attributes defined by this Working Group, document best practices for authors</li>
+        <li>For all attributes defined by this Working Group, document best practices for authors and, where appropriate, define author conformance requirements</li>
         <li>Collaborate with other groups to create mapping specifications for native host language semantics, generally
           but not always to be published by the ARIA WG</li>
         <li>Work with developers of testing tools that can be used to verify accessibility implementations by examining

--- a/2024/aria-charter.html
+++ b/2024/aria-charter.html
@@ -186,6 +186,7 @@
           necessary</li>
         <li>For each ARIA specification developed by this Working Group, create a corresponding Accessibility API
           Mappings specification defining the correct exposure for each platform</li>
+        <li>Maintain a specification for mapping HTML elements and attributes to platform accessibility APIs, and a separate specification that defines author conformance requirements for setting ARIA attributes</li>
         <li>For all attributes defined by this Working Group, document best practices for authors</li>
         <li>Collaborate with other groups to create mapping specifications for native host language semantics, generally
           but not always to be published by the ARIA WG</li>
@@ -279,7 +280,7 @@
             <p class="milestone"><b>Expected completion:</b> Q3 2025</p>
             <p><b>Adopted Draft:</b> <a href="https://www.w3.org/TR/2024/REC-html-aria-20240507/">https://www.w3.org/TR/2024/REC-html-aria-20240507/</a></p>
             <p><b>Exclusion Draft:</b> <a href="https://www.w3.org/TR/2021/CR-html-aria-20210706/">https://www.w3.org/TR/2021/CR-html-aria-20210706/</a>
-            Exclusion period <b>began</b> 2021-07-06; Exclusion period <b>ended:  2021-09-0.</b>.
+            Exclusion period <b>began</b> 2021-07-06; Exclusion period <b>ended:  2021-09-04.</b>.
             <p><b>Exclusion Draft Charter:</b> <a href="https://www.w3.org/2020/12/webapps-wg-charter.html">https://www.w3.org/2020/12/webapps-wg-charter.html</a></p>
           </dd>
           <dt class="spec" id="dpub-aria"><a href="https://www.w3.org/TR/dpub-aria-1.1/">Digital Publishing WAI-ARIA Module 1.1</a> (living standard) </dt>


### PR DESCRIPTION
Wonder if the ARIA WG would consider adding some description of the [HTML Accessibility API Mappings](https://www.w3.org/TR/html-aam-1.0/) and the [ARIA in HTML](https://www.w3.org/TR/html-aria/) spec in the Scope section. The suggested text was taken from the WebApps WG charter, where these two specs used to belong.