### PR TITLE
[ig/security] revert coord with AB to Process CG for process changes: making generic reference

### DIFF
--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -162,7 +162,7 @@
         <p>SING provides "<a href="https://www.w3.org/Guide/documentreview/">horizontal review</a>", offering groups on-request guidance on security issues and mitigations specific to their technologies. SING aims to offer this review as early in the technology development lifecycle as requested, observing that early feedback is often more helpful. SING may also seek out technologies that benefit from earlier security reviews and conduct such reviews on its initiative.</p>
         <p>SING incubates standards work on security issues by collecting requirements, prototyping, and/or initiating the work within the IG and recommending that the W3C move the work into other groups when appropriate.</p>
         <p>SING may recommend mitigations for security issues in existing features of the Web platform, up to and including their deprecation.</p>
-        <p>SING may provide input to the <a href="https://www.w3.org/groups/other/ab/">Advisory Board</a> on process changes that will improve security in Web standards, e.g., by establishing particular requirements or threat models for identifying and mitigating security issues in W3C Recommendations.</p>
+        <p>SING may provide input to the <a href="https://www.w3.org/community/w3process/">W3C Process Community Group</a> on process changes that will improve security in Web standards, e.g., by establishing particular requirements or threat models for identifying and mitigating security issues in W3C Recommendations.</p>
         <p>SING may recommend to the <a href="https://www.w3.org/groups/other/ac/">W3C Advisory Committee</a> and the <a href="https://www.w3.org/groups/other/tag/">W3C TAG</a> regarding the security impact of proposed standards.</p>
 
         <section id="section-out-of-scope">
@@ -247,7 +247,7 @@
          <section>
            <h3 id="w3c-coordination">W3C Groups</h3>
            <dl>
-             <dt><a href="https://www.w3.org/groups/other/ac/">Advisory Board (AB)</a></dt><dd>This Interest Group will coordinate with the AB to improve the process for security reviews.</dd>
+             <dt><a href="https://www.w3.org/community/w3process/">W3C Process Community Group (Process CG)</a></dt><dd>This Interest Group will coordinate with the Process CG to improve the process for security reviews.</dd>
              <dt><a href="https://www.w3.org/groups/other/tag/">Technical Architecture Group (TAG)</a></dt><dd>This Interest Group will collaborate with the TAG for the Self-Review Questionnaire: Security and Privacy, for a Threat Model related the Web Platform, and to harmonize and improve horizontal reviews.</dd>
              <dt><a href="https://www.w3.org/groups/ig/privacy/">Privacy Interest Group (PING)</a></dt><dd>This Interest Group will collaborate with PING for the Self-Review Questionnaire: Security and Privacy, for Threat Models related to Privacy and Harm, and to harmonize and improve horizontal reviews.</dd>
              <dt><a href="https://www.w3.org/groups/wg/webappsec/">Web Application Security Working Group (WebAppSec)</a></dt><dd>This Interest Group will coordinate with WebAppSec for developing security features and mitigations, and for Threat Models related to the Web Platform.</dd>

--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -162,7 +162,7 @@
         <p>SING provides "<a href="https://www.w3.org/Guide/documentreview/">horizontal review</a>", offering groups on-request guidance on security issues and mitigations specific to their technologies. SING aims to offer this review as early in the technology development lifecycle as requested, observing that early feedback is often more helpful. SING may also seek out technologies that benefit from earlier security reviews and conduct such reviews on its initiative.</p>
         <p>SING incubates standards work on security issues by collecting requirements, prototyping, and/or initiating the work within the IG and recommending that the W3C move the work into other groups when appropriate.</p>
         <p>SING may recommend mitigations for security issues in existing features of the Web platform, up to and including their deprecation.</p>
-        <p>SING may provide input to the <a href="https://www.w3.org/community/w3process/">W3C Process Community Group</a> on process changes that will improve security in Web standards, e.g., by establishing particular requirements or threat models for identifying and mitigating security issues in W3C Recommendations.</p>
+        <p>SING may provide input on W3C Process changes that will improve security in Web standards, e.g., by establishing particular requirements or threat models for identifying and mitigating security issues in W3C Recommendations.</p>
         <p>SING may recommend to the <a href="https://www.w3.org/groups/other/ac/">W3C Advisory Committee</a> and the <a href="https://www.w3.org/groups/other/tag/">W3C TAG</a> regarding the security impact of proposed standards.</p>
 
         <section id="section-out-of-scope">
@@ -247,7 +247,6 @@
          <section>
            <h3 id="w3c-coordination">W3C Groups</h3>
            <dl>
-             <dt><a href="https://www.w3.org/community/w3process/">W3C Process Community Group (Process CG)</a></dt><dd>This Interest Group will coordinate with the Process CG to improve the process for security reviews.</dd>
              <dt><a href="https://www.w3.org/groups/other/tag/">Technical Architecture Group (TAG)</a></dt><dd>This Interest Group will collaborate with the TAG for the Self-Review Questionnaire: Security and Privacy, for a Threat Model related the Web Platform, and to harmonize and improve horizontal reviews.</dd>
              <dt><a href="https://www.w3.org/groups/ig/privacy/">Privacy Interest Group (PING)</a></dt><dd>This Interest Group will collaborate with PING for the Self-Review Questionnaire: Security and Privacy, for Threat Models related to Privacy and Harm, and to harmonize and improve horizontal reviews.</dd>
              <dt><a href="https://www.w3.org/groups/wg/webappsec/">Web Application Security Working Group (WebAppSec)</a></dt><dd>This Interest Group will coordinate with WebAppSec for developing security features and mitigations, and for Threat Models related to the Web Platform.</dd>


### PR DESCRIPTION
suggest reverting to prior proposed SING charter specifically on the matter of coordinating with the Process CG instead of the AB. Process CG is where any proposed W3C Process changes should go first. The AB largely oversees the work of the Process CG, rather than separately receiving input on the Process.

cc: @chrisn @msporny @jyasskin 