### PR TITLE
[ig/security] add TC39-TG3 for ES/JS security model coord

### DIFF
--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -262,8 +262,8 @@
           <dl>
             <dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
             <dt><a href="https://isecom.org">ISECOM</a></dt><dd>Coordinate with ISECOM for security research methodologies.</dd>
-            <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
-            <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
+	    <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
+	    <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
 	    <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
             <dt><a href="https://owasp.org">OWASP</a></dt><dd>Coordinate with OWASP for application security requirements and testing methodologies.</dd>
           </dl>

--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -263,8 +263,8 @@
             <dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
             <dt><a href="https://isecom.org">ISECOM</a></dt><dd>Coordinate with ISECOM for security research methodologies.</dd>
 	    <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
-	    <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
-	    <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
+            <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
+            <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
             <dt><a href="https://owasp.org">OWASP</a></dt><dd>Coordinate with OWASP for application security requirements and testing methodologies.</dd>
           </dl>
         </section>

--- a/2024/ig-security.html
+++ b/2024/ig-security.html
@@ -262,8 +262,9 @@
           <dl>
             <dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
             <dt><a href="https://isecom.org">ISECOM</a></dt><dd>Coordinate with ISECOM for security research methodologies.</dd>
+            <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
             <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
-            <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
+	    <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
             <dt><a href="https://owasp.org">OWASP</a></dt><dd>Coordinate with OWASP for application security requirements and testing methodologies.</dd>
           </dl>
         </section>


### PR DESCRIPTION
Add TC39-TG3 for coordination on ES/JS security model aspects, as defined in their purpose on their page https://ecma-international.org/task-groups/tc39-tg3/