### PR TITLE
link charter-template Github & Issues links to its own

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -86,11 +86,12 @@
       </div>
 
       <!-- replace "draft charter" with "proposed charter" when the AC review starts -->
+      <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
       <!-- delete the GH link after AC review completed -->
       <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/@@">GitHub</a>.
+      on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html?todo=@@">GitHub</a>.
 
-    Feel free to raise <a href="https://github.com/w3c/@@/issues">issues</a></i>.
+    Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue%20state%3Aopen%20label%3Atemplate&amp;todo=@@">issues</a></i>.
           </p>
 
       <div id="details">


### PR DESCRIPTION
link the charter-template "GitHub" and "Issues" links to those for the charter-template itself as a placeholder, to make the charter-template itself and its issues more discoverable when viewing the charter template at github.io e.g. places (issues, PRs etc.) that link to https://w3c.github.io/charter-drafts/charter-template.html 

Include a URL param of todo=@@ as a strong hint / reminder that the URLs need to be replaced with those for the specific charter, and an HTML comment right above it instructing folks to do so