### PR TITLE
[wg/socialweb] Typo/editorial fixes to social-wg.html

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -55,7 +55,7 @@
           <li><a href="#background">Background</a></li>
           <li><a href="#scope">Scope</a></li>
           <li><a href="#deliverables">Deliverables</a></li>
-		  <li><a href="#success-criteria">Success Criteria</a></li>
+          <li><a href="#success-criteria">Success Criteria</a></li>
           <li><a href="#coordination">Coordination</a></li>
           <li><a href="#participation">Participation</a></li>
           <li><a href="#communication">Communication</a></li>
@@ -72,13 +72,13 @@
 
     <main>
       <h1 id="title"><i class="todo">DRAFT</i> Social Web Working Group Charter</h1>
-      <!-- replace DRAFT with PROPOSED when the AC reivew starts -->
+      <!-- replace DRAFT with PROPOSED when the AC review starts -->
       <!-- delete PROPOSED after AC review completed -->
 
       <p class="mission">The <strong>mission</strong> of the
           <a href="https://www.w3.org/groups/wg/social/">Social Web Working Group</a>
         is to maintain the W3C Recommendations, as well as related Notes, in the
-        area of Social Web.
+        area of the Social Web.
       </p>
 
       <div class="noprint">
@@ -89,11 +89,11 @@
 
       <!-- replace "draft charter" with "proposed charter" when the AC review starts -->
       <!-- delete the GH link after AC review completed -->
-      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <a href="https://github.com/w3c/charter-drafts">GitHub</a>.
+      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is 
+      <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/2025/social-wg.html">available on GitHub</a>.
 
-    Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues">issues</a>.
-          </p>
+      Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues">issues</a>.
+      </p>
 
       <div id="details">
         <table class="summary-table">
@@ -159,7 +159,7 @@
       <div id="background" class="background">
         <h2>Motivation and Background</h2>
         <p>
-          In the past few years, the Social Web Community Group acted as a
+          In the past few years, the Social Web Incubator Community Group acted as a
           maintainer for Social Web related specifications published by W3C.
           This Working Group would maintain the Recommendations and Notes in the
           Social Web area.
@@ -311,32 +311,32 @@
         </section>
       </section>
 
-	<section id="success-criteria">
-	  <h2>Success Criteria</h2>
+      <section id="success-criteria">
+        <h2>Success Criteria</h2>
 
-    <p>
+        <p>
       In order to update the Recommendation, each substantive change is expected to have
       <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent
         implementations</a> of every feature defined in the specification, where interoperability can be
       verified by passing open test suites, and two or more implementations interoperating with each other.
 
-    </p>
+        </p>
 
-    <p>
+        <p>
       Each substantive change should contain a section detailing all known security and privacy implications
       for implementers, authors, and end users.
-    </p>
+        </p>
 
-    <p>
+        <p>
       To promote interoperability, all changes made to specifications should have
       <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.
-    </p>
+        </p>
 
-    <p>
+        <p>
       This Working Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web
         Platform Design Principles</a>.
-    </p>
-  	</section>
+        </p>
+      </section>
 
       <section id="coordination">
         <h2>Coordination</h2>


### PR DESCRIPTION
Fixed a bunch of whitespace inconsistencies in the source, a few typos and omitted words, and link directly to the charter with more descriptive (accessible) link text.