### PR TITLE
[WG/timed-text] switching reference to STD-B62 from STD-B69 for ARIB

### DIFF
--- a/2025/timed-text-wg.html
+++ b/2025/timed-text-wg.html
@@ -509,8 +509,8 @@
               </dt>
               <dd>
                 ARIB develops standards for telecommunication and broadcasting, including
-                <a href="https://www.arib.or.jp/english/std_tr/broadcasting/std-b69.html">ARIB STD-B69</a>,
-                &quot;Exchange Format Of The Digital Closed Caption File For Digital Television Broadcasting System&quot;
+                <a href="https://www.arib.or.jp/english/std_tr/broadcasting/std-b62.html">ARIB STD-B62</a>,
+                &quot;Multimedia Coding Specification for Digital Broadcasting (Second Generation)&quot;
                 that defines the ARIB-TTML profile of TTML.
               </dd>
             </dl>


### PR DESCRIPTION
closes #665 

/cc @nigelmegitt @gkatsev @chrisn 

As discussed during TTWG call 2025-05-08, switching into STD-B62.
ref. https://www.w3.org/2025/05/08-tt-minutes.html#eb82