### PR TITLE
[template] Groups are expected to be guided by EW, Privacy, and Design principles

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -289,7 +289,7 @@ interoperability can be verified by passing open test suites.</p>
 		recommendations for maximising accessibility in implementations.</p>
 
     <!-- W3C statements -->
-    <p>This group is expected to follow the following documents:</p>
+    <p>This group is expected to be guided by the following documents:</p>
     <ul>
       <li><a href="https://www.w3.org/TR/ethical-web-principles/">Ethical Web Principles</a>,</li>
       <li><a href="https://www.w3.org/TR/privacy-principles/">Privacy Principles</a>,</li>

--- a/charter-template.html
+++ b/charter-template.html
@@ -288,9 +288,8 @@ interoperability can be verified by passing open test suites.</p>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>
 
-    <!-- Design principles -->
-    <p>This <i class="todo">(Working|Interest)</i> Group expects to follow the
-    TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.
+    <!-- W3C statements -->
+    <p>This group is expected to follow <a href="https://www.w3.org/TR/?status=stmt">W3C statements</a>.
     </p>
 
     <!-- Relevance and momentum -->

--- a/charter-template.html
+++ b/charter-template.html
@@ -289,7 +289,7 @@ interoperability can be verified by passing open test suites.</p>
 		recommendations for maximising accessibility in implementations.</p>
 
     <!-- W3C statements -->
-    <p>This group is expected to follow <a href="https://www.w3.org/TR/?status=stmt">W3C statements</a>.
+    <p>This group is expected to follow the <a href="https://www.w3.org/TR/ethical-web-principles/">ethical web principles</a> and the <a href="https://www.w3.org/TR/privacy-principles/">privacy principles</a>.
     </p>
 
     <!-- Relevance and momentum -->

--- a/charter-template.html
+++ b/charter-template.html
@@ -289,8 +289,12 @@ interoperability can be verified by passing open test suites.</p>
 		recommendations for maximising accessibility in implementations.</p>
 
     <!-- W3C statements -->
-    <p>This group is expected to follow the <a href="https://www.w3.org/TR/ethical-web-principles/">ethical web principles</a> and the <a href="https://www.w3.org/TR/privacy-principles/">privacy principles</a>.
-    </p>
+    <p>This group is expected to follow the following documents:</p>
+    <ul>
+      <li><a href="https://www.w3.org/TR/ethical-web-principles/">Ethical Web Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/privacy-principles/">Privacy Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</li>
+    </ul>
 
     <!-- Relevance and momentum -->
 	  <p><span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should have expressions of interest from at least two potential implementors before being incorporated in the specification.</p>


### PR DESCRIPTION
Now that we have 2 statements, I think it's time to update this sentence to make it clear that all groups are expected to follow W3C statements. In my mind, it's a given but might as well spell it out in charters for now at least.

cc @torgo @jyasskin @hadleybeeman @ylafon 
