### PR TITLE
[wg/timed-text] remove 'new' from continuous specs

### DIFF
--- a/2025/timed-text-wg.html
+++ b/2025/timed-text-wg.html
@@ -227,7 +227,7 @@
 
   </dl>
 
-  <h3>New Normative Specifications Continuously Under Development</h3>
+  <h3>Normative Specifications Continuously Under Development</h3>
   <p>The Working Group intends to develop the following new W3C normative specifications:</p>
   <dl>
     <dt id="webvtt" class="spec">

--- a/2025/timed-text-wg.html
+++ b/2025/timed-text-wg.html
@@ -228,7 +228,7 @@
   </dl>
 
   <h3>Normative Specifications Continuously Under Development</h3>
-  <p>The Working Group intends to develop the following new W3C normative specifications:</p>
+  <p>The Working Group intends to continue developing the following W3C normative specifications:</p>
   <dl>
     <dt id="webvtt" class="spec">
       <a href="https://www.w3.org/TR/webvtt1/">WebVTT: The Web Video Text Tracks Format</a>

--- a/2025/timed-text-wg.html
+++ b/2025/timed-text-wg.html
@@ -226,6 +226,7 @@
     </dd>
 
   </dl>
+  <p>The Working Group may develop additional Recommendation-track specifications.</p>
 
   <h3>Normative Specifications Continuously Under Development</h3>
   <p>The Working Group intends to continue developing the following W3C normative specifications:</p>
@@ -284,7 +285,6 @@
     </dd>
   </dl>
 
-  <p>The Working Group may develop additional Recommendation-track specifications.</p>
 </div>
 
 <div id="revisions">


### PR DESCRIPTION
closes #666 

as title, remove 'new' from heading title of 3.2 New Normative Specifications Continuously Under Development, per comment submitted to AC review.
Listed specifications are not 'new' since these are already in development, compared to ones listed in section 3.1.

/cc @nigelmegitt @gkatsev , how do you think?