### PR TITLE
update to 2025 Patent Policy

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -417,7 +417,7 @@ interoperability can be verified by passing open test suites.</p>
           Patent Policy
         </h2>
         <p>
-          This Working Group operates under the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+          This Working Group operates under the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> (Version of 15 May 2025). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
 
           For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr/">licensing information</a>.
         </p>


### PR DESCRIPTION
The 2025 Patent Policy is now operational. Currently, https://www.w3.org/policies/patent-policy/ points to https://www.w3.org/policies/patent-policy/20250515/.