### PR TITLE
[wg/social] Social Web charter updates

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -236,57 +236,36 @@
           <dl>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitypub/">ActivityPub</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
-
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/websub/">WebSub</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitystreams-vocabulary/">Activity Vocabulary</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
-
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/micropub/">Micropub</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
-
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
 
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/webmention/">Webmention</a></dt>
             <dd>
-              <p><b>Adopted Draft:</b> @@to be filled later@@
-              <p><b>Exclusion Draft:</b>  @@to be filled later@@
-                Associated @@to be filled later@@
-              <p><b>Exclusion Draft Charter:</b>  @@to be filled later@@
-
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
             </dd>
           </dl>
         </section>
@@ -332,10 +311,13 @@
       <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.
         </p>
 
-        <p>
-      This Working Group expects to follow the TAG <a href="https://www.w3.org/TR/design-principles/">Web
-        Platform Design Principles</a>.
-        </p>
+    <!-- W3C Statements and Web Platform Design Principles -->
+    <p>This group is expected to be guided by the following documents:</p>
+    <ul>
+      <li><a href="https://www.w3.org/TR/ethical-web-principles/">Ethical Web Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/privacy-principles/">Privacy Principles</a>,</li>
+      <li><a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</li>
+    </ul>
       </section>
 
       <section id="coordination">
@@ -370,16 +352,20 @@
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
             <dt><a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a></dt>
-            <dd>@@to be filled later@@</dd>
+            <dd>The SocialCG provides space to collaborate and coordinate for implementors who are building on any of the specifications published by the Social Web WG, and related technologies. It is also a place to incubate new proposals which build on or complement the Social Web WG recommendations.</dd>
           </dl>
         </section>
 
         <section>
           <h3 id="external-coordination">External Organizations</h3>
+
+          <p>None</p>
+<!--
           <dl>
             <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
             <dd><i class="todo">[specific nature of liaison]</i></dd>
           </dl>
+        -->
         </section>
       </section>
 
@@ -405,7 +391,7 @@
           for consideration upon their agreement to the terms of the
           <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
-        <p>Participants in the group are required (by the
+        <p>The Chairs should periodically look through the non-Members who have contributed to the Working Group and consider whether each one should be invited to participate as an Invited Expert. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href=''>apply to be an Invited Expert</a>. Participants in the group are required (by the
           <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>)
             to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
         </p>
@@ -429,18 +415,17 @@
         <p>
           Information about the group (including details about deliverables,
           issues, actions, status, participants, and meetings)
-          will be available from the <a href="">Social Web Working Group home page.</a>
+          will be available from the <a href="https://www.w3.org/groups/wg/social/">Social Web Working Group home page.</a>
         </p>
         <p>
           Most Social Web Working Group teleconferences will focus on discussion
           of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  <i class="todo">pick
-          one, or both, as appropriate:</i> on the public mailing list
-          <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a>
-          (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
-          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          This group primarily conducts its technical work on the public mailing list
+          <a id="public-name" href="mailto:public-socialweb@w3.org">public-socialweb@w3.org</a>
+          (<a href="https://lists.w3.org/Archives/Public/public-socialweb/">archive</a>)
+          or on <a id="public-github" href="https://www.w3.org/groups/wg/social/tools/#repositories">GitHub issues</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
@@ -478,8 +463,7 @@
 
           A call for consensus (CfC) will be issued for all resolutions (for
           example, via email, GitHub issue or web-based survey), with a response
-          period from <span id='cfc'><i class="todo">[pick a duration within:]
-          one week to 10 working days</i></span>, depending on the chair's
+          period of <span id='cfc'>one week to 10 working days</i></span>, depending on the chair's
           evaluation of the group consensus on the issue.
 
           If no objections are raised by the end of the response period, the
@@ -562,16 +546,56 @@
               </tr>
               <tr>
                 <th>
-                  <a class="todo" href="">Initial Charter</a>
+                  <a href="https://www.w3.org/2013/socialweb/social-wg-charter">Initial Charter</a>
                 </th>
                 <td>
-                  <i class="todo">[dd monthname yyyy]</i>
+                  2014-07-21
                 </td>
                 <td>
-                  <i class="todo">[dd monthname yyyy] (start +2 years)</i>
+                  2016-12-31
                 </td>
                 <td>
-                  <i class="todo">none</i>
+                  
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016OctDec/0057.html">Charter Extension</a>
+                </th>
+                <td>
+                  2017-01-01
+                </td>
+                <td>
+                   2017-06-30
+                </td>
+                <td>
+                  none
+                </td>
+              </tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2017AprJun/0065.html">Charter Extension</a>
+                </th>
+                <td>
+                  2017-07-01
+                </td>
+                <td>
+                   2017-12-31
+                </td>
+                <td>
+                  none
+                </td>
+              </tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2018JanMar/0013.html">Charter Extension</a>
+                </th>
+                <td>
+                  2018-01-01
+                </td>
+                <td>
+                   2018-01-31
+                </td>
+                <td>
+                  none
                 </td>
               </tr>
             </tbody>

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -339,7 +339,13 @@
           when major changes occur in a specification following a review.
         </p>
 
-        <p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a></dt>
+            <dd><p>The SocialCG provides space to collaborate and coordinate for implementors who are building on any of the specifications published by the Social Web WG, and related technologies. It is also a place to incubate new proposals which build on or complement the Social Web WG recommendations.</p>
+                      <p>
           This group is expected to coordinate with the
           <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>
           on consensus-based proposals related to content changes for the
@@ -348,11 +354,7 @@
           with this Charter.
         </p>
 
-        <section>
-          <h3 id="w3c-coordination">W3C Groups</h3>
-          <dl>
-            <dt><a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a></dt>
-            <dd>The SocialCG provides space to collaborate and coordinate for implementors who are building on any of the specifications published by the Social Web WG, and related technologies. It is also a place to incubate new proposals which build on or complement the Social Web WG recommendations.</dd>
+            </dd>
           </dl>
         </section>
 

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -182,12 +182,9 @@
         </p>
         <!-- If incubation, the scope will need to be expanded -->
 
-        <section id="section-out-of-scope">
+<!--        <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
-          <!-- If incubation, delete the section. -->
-          <p>
-            Changes that add new functionality (<a href="https://www.w3.org/policies/process/#class-4">class 4</a>) are out of scope.
-          </p>
+          -->
         </section>
 
         <section id="section-workflow-for-active-items">
@@ -277,16 +274,19 @@
             Tentative Deliverables
           </h3>
           <p>Depending on the incubation progress, interest from multiple implementers, and the consensus
-            of the Group participants, the Working Group may adopt the following documents
-             as Rec-track specifications:</p>
+            of the Group participants, the Working Group may adopt the following document
+             as Rec-track specification:</p>
           <dl>
-            <dt id="web-incubated-foo" class="spec"><a href="#">Web <i class="todo">[spec name]</i></a></dt>
+            <dt id="lola" class="spec"><a href="https://swicg.github.io/activitypub-data-portability/lola">LOLA</a></dt>
             <dd>
-              <p>This specification defines <i class="todo">[concrete description]</i>.</p>
-              <p class="draft-status"><b>Draft state:</b>
-                Proposal in <a href=""><i class="todo">[other name]</i> Community Group</a></p>
+              <p>LOLA is a proposal for live online account portability between two ActivityPub servers at the request of a user.</p>
+              <p class="draft-status"><b>Draft state: CG Draft</b></p>
             </dd>
           </dl>
+          <p>
+            In coordination with the the
+          <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>, the Working Group is expected to follow the <a href="https://github.com/swicg/potential-charters/blob/main/stage-process.md">CG/WG Proposal Stages</a>.
+          </p>
         </section>
       </section>
 


### PR DESCRIPTION
- Remove class 4 changes from out of scope
- Add LOLA as tentative deliverables
- Link to CG/WG Process
- Align with latest charter templates

Replaces https://github.com/w3c/charter-drafts/pull/657