### PR TITLE
fix link to GH source in webextensions-wg.html

### DIFF
--- a/2025/webextensions-wg.html
+++ b/2025/webextensions-wg.html
@@ -86,7 +86,7 @@
       <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
       <!-- delete the GH link after AC review completed -->
       <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/2020/webextensions-wg.html">GitHub</a>.
+      on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/2025/webextensions-wg.html">GitHub</a>.
 
     Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue%20state%3Aopen%20title%3A[wg/webextensions]">issues</a></i>.
           </p>


### PR DESCRIPTION
s/2020/2025 in href to link to GH source of charter for webextensions-wg.html