### PR TITLE
webai-ig.html fix links to charter & issues on gh

### DIFF
--- a/2025/webai-ig.html
+++ b/2025/webai-ig.html
@@ -92,9 +92,9 @@
       <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
       <!-- delete the GH link after AC review completed -->
       <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html?todo=@@">GitHub</a>.
+      on <i class="todo"><a href="https://w3c.github.io/charter-drafts/2025/webai-ig.html">GitHub</a>.
 
-    Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue%20state%3Aopen%20label%3Atemplate&amp;todo=@@">issues</a></i>.
+    Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues">issues</a></i>.
           </p>
 
       <div id="details">


### PR DESCRIPTION
Fix links to charter is available on GitHub, and where to raise issues.