### PR TITLE
remove unneeded CSS rule

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -9,11 +9,6 @@
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
     <style>
-      main {
-        max-width: 60em;
-        margin: 0 auto;
-      }
-
       ul#navbar {
         font-size: small;
       }


### PR DESCRIPTION
The width/margin of <main> is now set in https://www.w3.org/2006/02/charter-style.css