### PR TITLE
[template] Consistently distinguish between WG|IG participants, 

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -120,7 +120,7 @@
               Chairs
             </th>
             <td>
-              <i class="todo">[chair name] (affiliation)</i> (<i class="todo">Remember that Listing Member organizations names is a W3C Member benefit. Non-Member (co)-Chair(s) are to be affiliated as 'W3C Invited Expert'.</i>)
+              <i class="todo">[chair name] (affiliation)</i> (<i class="todo">Remember that Listing W3C-Member organizations names is a W3C Member benefit. Non-W3C-Member (co)-Chair(s) are to be affiliated as 'W3C Invited Expert'.</i>)
             </td>
           </tr>
           <tr>
@@ -188,7 +188,7 @@
             <dd>
               <p>This specification will define <i class="todo">[concrete description]</i>.</p>
 
-              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">Member Submission</a>]</i></p>
+              <p class="draft-status"><b>Draft state:</b> <i class="todo">[No draft | <a href="#">Use Cases and Requirements</a> | <a href="#">Editor's Draft</a> | <a href="#">W3C-Member Submission</a>]</i></p>
               <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
               <p class=todo>If this is a new technical report that will start as a copy of a different TR:</p>
               <p><b>Initial Text:</b> The <span class="todo">title, stable URL, and publication date of the existing technical report which will serve as the initial text of the deliverable.</span>
@@ -342,10 +342,10 @@ interoperability can be verified by passing open test suites. In order to advanc
           To be successful, this <i class="todo">(Working|Interest)</i> Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the <i class="todo">(Working|Interest)</i> Group. There is no minimum requirement for other Participants.
         </p>
         <p>
-          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>. The group also welcomes non-Members to make technical contributions for ongoing work, provided they agree to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>. The group also welcomes non-participants to make technical contributions for ongoing work, provided they agree to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
         <p>
-          The Chairs should periodically look through the non-Members who have contributed to the <i class="todo">(Working|Interest)</i> Group <i class="todo">or the [name of an associated Community Group, if any]</i> and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/[shortname]/instructions/">apply to be an Invited Expert</a>.
+          The Chairs should periodically look through the non-W3C-Member contributors to the <i class="todo">(Working|Interest)</i> Group <i class="todo">or the [name of an associated Community Group, if any]</i> and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-W3C-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/[shortname]/instructions/">apply to be an Invited Expert</a>.
         </p>
         <p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the
           W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.</p>
@@ -373,7 +373,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
-          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+          The group may use a W3C-Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
         </p>
       </section>
 

--- a/charter-template.html
+++ b/charter-template.html
@@ -373,7 +373,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
-          The group may use a W3C-Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+          The group may use a <a href="https://www.w3.org/policies/process/#Member-only">Member-only</a> mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
         </p>
       </section>
 


### PR DESCRIPTION
on the one hand, and W3C Members on the other. Fix #664