### PR TITLE
[wg/pointer-events] Update charter for PE4

### DIFF
--- a/2025/pointer-events-wg.html
+++ b/2025/pointer-events-wg.html
@@ -158,11 +158,11 @@
         <h2>Scope</h2>
         <p>Pointer Events provide support for handling mouse, touch, and pen input for web sites and web applications through DOM Events. For example, a web application developer using Pointer Events would only have use a single model, rather than separate code paths for mouse events, touch events, and pen-tablet events, developing web applications using pointers much more efficient and inclusive.</p>
 
-        <p>This Working Group seeks to enhance the features delivered in the <a href="https://www.w3.org/TR/pointerevents2/">Pointer Events Recommendation</a> by exploring changes, such as:</p>
+        <p>This Working Group seeks to enhance the features delivered in the <a href="https://www.w3.org/TR/pointerevents3/">Pointer Events Recommendation</a> by exploring changes, such as:</p>
           <ul>
             <li>Addition of <a href="https://www.w3.org/TR/pointerevents3/#details-of-touch-action-values">direction-specific values for <code>touch-action</code></a>, giving finer-grained control of panning touch behaviors</li>
-            <li>Support for querying <a href="https://www.w3.org/TR/pointerevents3/#coalesced-and-predicted-events">coalesced and predicted pointer events</a></li>
-            <li>Clarifying relationship between pointer events and other behaviors/event models, such as drag and drop</li>
+            <li>Clarifying relationship between pointer events and other behaviors/event models, such as mouse events, pointer lock, and drag and drop</li>
+			<li>Exploration of how basic high-level gestures – such as "swipe left" or "two-finger tap" – could be exposed to web content authors</li>
             <li>Additional clarifications of API behavior and performance optimizations (see <a href="https://github.com/w3c/pointerevents/issues?q=is%3Aissue+is%3Aopen+label%3Av3">issues marked for future consideration in GitHub</a>)</li>
           </ul>
 
@@ -171,7 +171,7 @@
             <p>The following features are out of scope, and will not be addressed by this Working group.</p>
 
             <ul class="out-of-scope">
-              <li>Gestures. Examples of out-of-scope gesture functionality and APIs include, but are not limited to, the following:
+              <li>Gesture internals, how user agents determine if an interaction is intended to be a gesture. Examples of out-of-scope gesture functionality and APIs include, but are not limited to, the following:
                 <ul>
                   <li>Comparisons between multiple pointers to determine an action (e.g., panning for scrollable regions, pinch for zooming, press-and-hold for a mouse right-click).</li>
                   <li>Comparisons between time stamps of pointers to determine an action.</li>


### PR DESCRIPTION
* removed the points from "seeks to enhance" that are now done and delivered by PE3
* expanded the "clarifying relationship" point
* added the "exploration of high-level gestures"
* tweaked language for out-of-scope gestures, to clarify that we don't seek to define HOW user agents determine that something is a gesture

/cc @plehegar 