### PR TITLE
[template] Simplify the success clause in the charter template

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -265,7 +265,7 @@
 		  <a href="https://www.w3.org/policies/process/#RecsCR" title="Candidate Recommendation">Candidate Recommendation</a>, each normative specification is expected to have
 		  <a href="https://www.w3.org/policies/process/#implementation-experience">at least two independent interoperable
 			  implementations</a> of every feature defined in the specification, where
-interoperability can be verified by passing open test suites. In order to advance beyond Candidate Recommendation, each normative specification must have an open test suite of every feature defined in the specification.</p>
+interoperability can be verified by passing open test suites.</p>
 	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
     <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span>
       To promote interoperability, all changes made to specifications


### PR DESCRIPTION
Removed a redundant sentence regarding open test suites in the charter template.