### PR TITLE
[wg/social] Participation: Move section from scope, Remove Chair Election, Add SWICG for Invited Experts

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -183,33 +183,9 @@
 
 <!--        <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
+        </section>
           -->
-        </section>
 
-        <section id="section-workflow-for-active-items">
-          <h3 id="workflow-for-active-items">Workflow for Active Items</h3>
-          <p>
-            It is important for the health of the group and the quality of review
-            to avoid too much work being scheduled concurrently. For
-            this reason, the Chair(s) may choose to stagger the scheduling of
-            kick-offs, active work, and review of work items, or even defer
-            final Chair and member review of items into a queue, if they feel
-            they cannot adequately supervise the requested work in
-            parallel. The amount of effort and time needed to support work items
-            varies; even for a given work item, support may require more from
-            one Chair than another based on familiarity or expertise, so rather
-            than set a fixed quota, it is expected that Chairs will be open and
-            public about these constraints, and especially clear with Editors
-            and champions in the process of rallying support for items entering
-            that queue.
-          </p>
-          <p>
-            If there is a substantial amount of work being queued, or if work is
-            ramping up outside the expertise of the current Chair(s), they are
-            invited to recruit additional Chairs and call elections for an
-            additional co-Chair.
-          </p>
-        </section>
 
       </section>
 
@@ -412,6 +388,31 @@
           <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>)
             to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
         </p>
+
+        <section id="section-workflow-for-active-items">
+          <h3 id="workflow-for-active-items">Workflow for Active Items</h3>
+          <p>
+            It is important for the health of the group and the quality of review
+            to avoid too much work being scheduled concurrently. For
+            this reason, the Chair(s) may choose to stagger the scheduling of
+            kick-offs, active work, and review of work items, or even defer
+            final Chair and member review of items into a queue, if they feel
+            they cannot adequately supervise the requested work in
+            parallel. The amount of effort and time needed to support work items
+            varies; even for a given work item, support may require more from
+            one Chair than another based on familiarity or expertise, so rather
+            than set a fixed quota, it is expected that Chairs will be open and
+            public about these constraints, and especially clear with Editors
+            and champions in the process of rallying support for items entering
+            that queue.
+          </p>
+          <p>
+            If there is a substantial amount of work being queued, or if work is
+            ramping up outside the expertise of the current Chair(s), they are
+            invited to recruit additional Chairs and call elections for an
+            additional co-Chair.
+          </p>
+        </section>
       </section>
 
       <section id="communication">

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -384,7 +384,7 @@
           for consideration upon their agreement to the terms of the
           <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
-        <p>The Chairs should periodically look through the non-Members who have contributed to the Working Group and consider whether each one should be invited to participate as an Invited Expert. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href=''>apply to be an Invited Expert</a>. Participants in the group are required (by the
+        <p>The Chairs should periodically look through the non-Members who have contributed to the <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a> and consider whether each one should be invited to participate as an Invited Expert. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href='https://www.w3.org/groups/wg/pointer-events/apply-as-invited-expert/'>apply to be an Invited Expert</a>. Participants in the group are required (by the
           <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>)
             to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
         </p>

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -409,8 +409,7 @@
           <p>
             If there is a substantial amount of work being queued, or if work is
             ramping up outside the expertise of the current Chair(s), they are
-            invited to recruit additional Chairs and call elections for an
-            additional co-Chair.
+            invited to help recruit additional Chairs.
           </p>
         </section>
       </section>

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -384,7 +384,7 @@
           for consideration upon their agreement to the terms of the
           <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
-        <p>The Chairs should periodically look through the non-Members who have contributed to the <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a> and consider whether each one should be invited to participate as an Invited Expert. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href='https://www.w3.org/groups/wg/pointer-events/apply-as-invited-expert/'>apply to be an Invited Expert</a>. Participants in the group are required (by the
+        <p>The Chairs should periodically look through the non-Members who have contributed to the <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a> and consider whether each one should be invited to participate as an Invited Expert. If a non-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/invited-experts/#instructions">apply to be an Invited Expert</a>. Participants in the group are required (by the
           <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>)
             to follow the W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.
         </p>


### PR DESCRIPTION
This addresses the folllowing comments:
- "Workflow for Active Items" would probably be a better fit under "Participation" than under "Scope"
that same subsection refers to "co-chair" elections, which I don't think are in line with the Process
- In the participation section, and given the strong influence of the SWICG, it seems odd that the CG is not mentioned in the paragraph about potential Invited Experts. The charter template suggests adding that, if there is a relevant CG.

cc https://github.com/w3c/strategy/issues/435