### PR TITLE
[wg/social] Added REC Initial Text

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -234,33 +234,39 @@
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
               <p class="milestone"><b>Expected completion:</b> Q3 2026</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2018/REC-activitypub-20180123/">ActivityPub, 23 January 2018</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitystreams-core/">Activity Streams</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
               <p class="milestone"><b>Expected completion:</b> Q3 2026</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-activitystreams-core-20170523/">Activity Streams, 23 May 2017</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/activitystreams-vocabulary/">Activity Vocabulary</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
               <p class="milestone"><b>Expected completion:</b> Q3 2026</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-activitystreams-vocabulary-20170523/">Activity Vocabulary, 23 May 2017</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/websub/">WebSub</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2018/REC-websub-20180123/">WebSub, 23 January 2018</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/micropub/">Micropub</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-micropub-20170523/">Micropub, 23 May 2017</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
-
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-ldn-20170502/">Linked Data Notifications, 2 May 2017</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/webmention/">Webmention</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-webmention-20170112/">Webmention, 12 January 2017</a></p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
This address:
- the list of deliverables should add "Initial text" entries, with links to the dated versions of the Rec

cc https://github.com/w3c/strategy/issues/435