### PR TITLE
[wg/social] Update mission, background and scope

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -78,7 +78,7 @@
       <p class="mission">The <strong>mission</strong> of the
           <a href="https://www.w3.org/groups/wg/social/">Social Web Working Group</a>
         is to maintain the W3C Recommendations, as well as related Notes, in the
-        area of the Social Web.
+        area of the Social Web and may also adopt <a href="#incubation">further deliverables</a>.
       </p>
 
       <div class="noprint">
@@ -160,7 +160,7 @@
         <p>
           In the past few years, the Social Web Incubator Community Group acted as a
           maintainer for Social Web related specifications published by W3C.
-          This Working Group would maintain the Recommendations and Notes in the
+          This Working Group will take over the maintenance of the Recommendations and Notes in the
           Social Web area.
         </p>
       </div>
@@ -178,6 +178,10 @@
           <a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a>, and
           <a href="https://www.w3.org/TR/webmention/">Webmention</a>
           specifications, as well as related Notes.
+        </p>
+        <p>
+          Depending on the incubation progress, interest from multiple implementers, and the consensus
+          of the Group participants, the Working Group may also adopt <a href="#incubation">further deliverables</a>.
         </p>
         <!-- If incubation, the scope will need to be expanded -->
 

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -160,7 +160,7 @@
         <p>
           In the past few years, the Social Web Incubator Community Group acted as a
           maintainer for Social Web related specifications published by W3C.
-          This Working Group will take over the maintenance of the Recommendations and Notes in the
+          This Working Group will maintain Recommendations and Notes in the
           Social Web area.
         </p>
       </div>

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -78,7 +78,7 @@
       <p class="mission">The <strong>mission</strong> of the
           <a href="https://www.w3.org/groups/wg/social/">Social Web Working Group</a>
         is to maintain the W3C Recommendations, as well as related Notes, in the
-        area of the Social Web and may also adopt <a href="#incubation">further deliverables</a>.
+        area of the Social Web and may also adopt <a href="#incubation">tentative deliverables</a>.
       </p>
 
       <div class="noprint">
@@ -181,7 +181,7 @@
         </p>
         <p>
           Depending on the incubation progress, interest from multiple implementers, and the consensus
-          of the Group participants, the Working Group may also adopt <a href="#incubation">further deliverables</a>.
+          of the Group participants, the Working Group may also adopt <a href="#incubation">tentative deliverables</a>.
         </p>
         <!-- If incubation, the scope will need to be expanded -->
 


### PR DESCRIPTION
includes new features from incubation.

Address the comments:
* the mission statement, motivation and scope all claim the group will do only maintenance, but since it has a tentative new deliverable (LOLA), that should probably be clarified - I assume the intent is that LOLA is the only CG deliverable that could be adopted without rechartering. The Recommendation-update-specific success criteria wouldn't work for that deliverable.
* the phrasing of the scope is a bit confusing: "SWICG acted as maintainer [...] This WG would maintain…". Maybe "This WG will bring consensus updates to the Recommendations", or "will take over maintenance of these Recommendations"
* I also noticed (agreeing again with dontcallmedom and caribouW3) that the mission and scope talk solely about maintenance but the tentative LOLA deliverable is outside that scope. Does that mean that, if adopted, the WG would recharter? (and thus, is that the reason for the odd mention of proposals outside the charter scope?) If so, that seems like an unnecessary extra step; just put it clearly in scope, and if it ends up not happening, that is okay.

cc https://github.com/w3c/strategy/issues/435
