### PR TITLE
[wg/social] Realign with charter template re security/privacy

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -319,7 +319,7 @@
         </p>
 
         <p>
-      Each specification should contain separate sections detailing all known security and privacy implications for implementers, authors, and end users.
+      Each specification should contain separate sections detailing all known security and privacy implications for implementers, authors, and users.
         </p>
 
         <p>

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -319,8 +319,7 @@
         </p>
 
         <p>
-      Each substantive change should contain a section detailing all known security and privacy implications
-      for implementers, authors, and end users.
+      Each specification should contain separate sections detailing all known security and privacy implications for implementers, authors, and end users.
         </p>
 
         <p>


### PR DESCRIPTION
There was some ancient text there that needed to be relaligned.

Address the comments:
* I'm not sure a "substantive change" can (or should) "contain a section" on privacy and security; I think it's more likely that each substantive change with privacy and security implications would be reflected in a privacy & security considerations section
* The wording on security and privacy is very odd (only one security and one privacy section is needed, per spec, although these must be separate sections). Looks like a partial edit to me, and from an older charter template at that.

cc https://github.com/w3c/strategy/issues/435