### PR TITLE
[wg/social] Clarified coordination with the CG

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -366,15 +366,9 @@
             </dd>
             <dt><a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a></dt>
             <dd><p>The SocialCG provides space to collaborate and coordinate for implementors who are building on any of the specifications published by the Social Web WG, and related technologies. It is also a place to incubate new proposals which build on or complement the Social Web WG recommendations.</p>
-                      <p>
-          This group is expected to coordinate with the
-          <a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a>
-          on consensus-based proposals related to content changes for the
-          Social Web Working Group Deliverables.
-          The Chairs of this group should reject proposals that are incompatible
-          with this Charter.
-        </p>
-
+            <p>
+              The Working Group is expected to request reviews from the Community Group of all of the Working Group deliverables.
+            </p>
             </dd>
           </dl>
         </section>

--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -367,7 +367,7 @@
             <dt><a href="https://www.w3.org/groups/cg/socialcg/">Social Web Incubator Community Group</a></dt>
             <dd><p>The SocialCG provides space to collaborate and coordinate for implementors who are building on any of the specifications published by the Social Web WG, and related technologies. It is also a place to incubate new proposals which build on or complement the Social Web WG recommendations.</p>
             <p>
-              The Working Group is expected to request reviews from the Community Group of all of the Working Group deliverables.
+              The Working Group will request reviews from the Community Group of all WG deliverables.
             </p>
             </dd>
           </dl>


### PR DESCRIPTION
Address
[[
 In section 5.1, the paragraphs under Social Web CG is quite strange. The first sentence seems to suggest that implementors will gather in the CG. The second aragraph IIUC says that the CG will give approval to WG-proposed changes to the deliverables. (it is somewhat true, wrt Wide review, but not for individual decisions). I don't know what "The Chairs of this group should reject proposals that are incompatible with this Charter." really means. "Incompatible" there is an obscure terminology.

I propose:

replace this part of the charter with something more boilerplate like "the CG is expected to review the deliverables produced by the WG." and maybe "the Social Web CG will continue to incubate specifications that are not covered in this charter".
]]

cc https://github.com/w3c/strategy/issues/435