### PR TITLE
[template] Align with Web Platform Principles

### DIFF
--- a/charter-template.html
+++ b/charter-template.html
@@ -277,7 +277,7 @@ interoperability can be verified by passing open test suites. In order to advanc
     <!-- Horizontal review -->
 
     <p>Each specification should contain separate sections detailing all known security and
-      privacy implications for implementers, Web authors, and end users.</p>
+      privacy implications for implementers, Web authors, and users.</p>
 
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and


### PR DESCRIPTION
s/end user/user/

[[
drop "end". The Web Platform Design Principles just uses "users" per https://www.w3.org/TR/design-principles/#priority-of-constituencies
]]
https://github.com/w3c/charter-drafts/pull/724