### PR TITLE
[ig/webai] changed link to join (wg -> ig)

### DIFF
--- a/2025/webai-ig.html
+++ b/2025/webai-ig.html
@@ -84,7 +84,7 @@
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
       <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join/">Join the Web & AI Interest Group.</a></p>
+        <p class="join"><a href="https://www.w3.org/groups/ig/[shortname]/join/">Join the Web & AI Interest Group.</a></p>
       </div>
 
       <!-- replace "draft charter" with "proposed charter" when the AC review starts -->


### PR DESCRIPTION
changed 
https://www.w3.org/groups/wg/webai/join/ 
to
https://www.w3.org/groups/ig/webai/join/