### PR TITLE
[ig/webai] corrected Accessibility group URL

### DIFF
--- a/2025/webai-ig.html
+++ b/2025/webai-ig.html
@@ -247,7 +247,7 @@
             <dd>coordinate on various time series AI architectures and focusing on their efficient implementation in web environments.</dd>
           </dl>
           <dl>
-            <dt><a href="https://www.w3.org/groups/cg/waits/">Accessible Platform Architectures Working Group</a></dt>
+            <dt><a href="https://www.w3.org/WAI/about/groups/apawg/">Accessible Platform Architectures Working Group</a></dt>
             <dd>coordinate on AI and Accessibililty work in Research Questions Task Force.</dd>
           </dl>
           <dl>


### PR DESCRIPTION
corrected Accessibility group URL to https://www.w3.org/WAI/about/groups/apawg/