### PR TITLE
[wg/social] editorial: alpha-sort deliverables social-wg.html

### DIFF
--- a/2025/social-wg.html
+++ b/2025/social-wg.html
@@ -228,25 +228,25 @@
               <p class="milestone"><b>Expected completion:</b> Q3 2026</p>
               <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-activitystreams-vocabulary-20170523/">Activity Vocabulary, 23 May 2017</a></p>
             </dd>
-            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/websub/">WebSub</a></dt>
+            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
-              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2018/REC-websub-20180123/">WebSub, 23 January 2018</a></p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-ldn-20170502/">Linked Data Notifications, 2 May 2017</a></p>
             </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/micropub/">Micropub</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
               <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-micropub-20170523/">Micropub, 23 May 2017</a></p>
             </dd>
-            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a></dt>
-            <dd>
-              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
-              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-ldn-20170502/">Linked Data Notifications, 2 May 2017</a></p>
-            </dd>
             <dt id="activity" class="spec"><a href="https://www.w3.org/TR/webmention/">Webmention</a></dt>
             <dd>
               <p class="draft-status"><b>Draft state:</b> Recommendation</p>
               <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2017/REC-webmention-20170112/">Webmention, 12 January 2017</a></p>
+            </dd>
+            <dt id="activity" class="spec"><a href="https://www.w3.org/TR/websub/">WebSub</a></dt>
+            <dd>
+              <p class="draft-status"><b>Draft state:</b> Recommendation</p>
+              <p><b>Initial text:</b> <a href="https://www.w3.org/TR/2018/REC-websub-20180123/">WebSub, 23 January 2018</a></p>
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
alphabetically sort deliverables, as current order does not convey any particular semantic and an alpha-sort helps reduce the chance of misinterpretation of the order meaning anything