### PR TITLE
[wg/pointer-events] Drop the use of the term 'gesture internal'

### DIFF
--- a/2025/pointer-events-wg.html
+++ b/2025/pointer-events-wg.html
@@ -166,7 +166,7 @@
             <p>The following features are out of scope, and will not be addressed by this Working group.</p>
 
             <ul class="out-of-scope">
-              <li>Gesture internals, how user agents determine if an interaction is intended to be a gesture. Examples of out-of-scope gesture functionality and APIs include, but are not limited to, the following:
+              <li>How user agents determine if an interaction is intended to be a gesture. Examples include, but are not limited to, the following:
                 <ul>
                   <li>Comparisons between multiple pointers to determine an action (e.g., panning for scrollable regions, pinch for zooming, press-and-hold for a mouse right-click).</li>
                   <li>Comparisons between time stamps of pointers to determine an action.</li>


### PR DESCRIPTION
That use was confusing since it also talked about "APIs".

Just kept "How user agents determine if an interaction is intended to be a gesture"

https://www.w3.org/2025/12/17-pointerevents-minutes.html#ddfa

cc https://github.com/w3c/strategy/issues/515

cc @patrickhlauke 