### PR TITLE
[wg/das] updated links and dates in metadata of deliverables

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -269,19 +269,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2022/WD-battery-status-20220203/">https://www.w3.org/TR/2022/WD-battery-status-20220203/</a>
+              "https://www.w3.org/TR/2024/WD-battery-status-20241024/">https://www.w3.org/TR/2024/WD-battery-status-20241024/</a> (24 October 2024)
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "http://www.w3.org/TR/2016/CR-battery-status-20160707/">http://www.w3.org/TR/2016/CR-battery-status-20160707/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2016/CR-battery-status-20160707/">https://www.w3.org/TR/2016/CR-battery-status-20160707/</a> (7 July 2016)
+                associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Jul/0005.html">Call for Exclusion</a> on 2016-07-07, opportunity until 2016-09-05
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/wake-lock/">Screen Wake Lock API</a>
@@ -296,19 +292,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-screen-wake-lock-20230719/">https://www.w3.org/TR/2023/WD-screen-wake-lock-20230719/</a>
+              "https://www.w3.org/TR/2024/WD-screen-wake-lock-20241024/">https://www.w3.org/TR/2024/WD-screen-wake-lock-20241024/</a> (24 October 2024)
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a> (14 December 2017)
+                associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Jul/0005.html">Call for Exclusion</a> on 2016-07-07, opportunity until 2016-09-05
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
             <p class="issue">
               <b>Note:</b> This work is a joint deliverable with the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>.
             </p>
@@ -328,17 +320,13 @@
               <b>Adopted Draft</b>: <a href=
               "https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a> (14 December 2017)
+                associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Jul/0005.html">Call for Exclusion</a> on 2016-07-07, opportunity until 2016-09-05
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor
@@ -355,19 +343,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/CRD-generic-sensor-20230810/">https://www.w3.org/TR/2023/CRD-generic-sensor-20230810/</a>
+              "https://www.w3.org/TR/2025/CRD-generic-sensor-20251211/">https://www.w3.org/TR/2025/CRD-generic-sensor-20251211/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2019/CR-generic-sensor-20191212/">https://www.w3.org/TR/2019/CR-generic-sensor-20191212/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2019/CR-generic-sensor-20191212/">https://www.w3.org/TR/2019/CR-generic-sensor-20191212/</a> (12 December 2019)
+                associated <a href="https://www.w3.org/mid/cfe-7281-de5379e5d2ea5f48aa29d87ab75bf6813b0e39b9@w3.org">Call for Exclusion</a> on 2019-12-12, opportunity until 2020-02-10 
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/proximity/">Proximity Sensor</a>
@@ -383,19 +367,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-proximity-20230130/">https://www.w3.org/TR/2023/WD-proximity-20230130/</a>
+              "https://www.w3.org/TR/2025/WD-proximity-20250212/">https://www.w3.org/TR/2025/WD-proximity-20250212/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "http://www.w3.org/TR/2012/WD-proximity-20121206/">http://www.w3.org/TR/2012/WD-proximity-20121206/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2012/WD-proximity-20121206/">https://www.w3.org/TR/2012/WD-proximity-20121206/</a> (6 December 2012)
+                associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2012Dec/0000.html">Call for Exclusion</a> on 2012-12-06, opportunity until 2013-02-04
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "http://www.w3.org/2011/07/DeviceAPICharter.html">http://www.w3.org/2011/07/DeviceAPICharter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2011/07/DeviceAPICharter.html">https://www.w3.org/2011/07/DeviceAPICharter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/ambient-light/">Ambient Light
@@ -412,19 +392,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-ambient-light-20230721/">https://www.w3.org/TR/2023/WD-ambient-light-20230721/</a>
+              "https://www.w3.org/TR/2025/WD-ambient-light-20250212/">https://www.w3.org/TR/2025/WD-ambient-light-20250212/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2018/CR-ambient-light-20180320/">https://www.w3.org/TR/2018/CR-ambient-light-20180320/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2018/CR-ambient-light-20180320/">https://www.w3.org/TR/2018/CR-ambient-light-20180320/</a> (20 March 2018)
+                associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2018Mar/0008.html">Call for Exclusion</a> on 2018-03-20, opportunity until 2018-05-19 
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/accelerometer/">Accelerometer</a>
@@ -440,19 +416,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/CRD-accelerometer-20230130/">https://www.w3.org/TR/2023/CRD-accelerometer-20230130/</a>
+              "https://www.w3.org/TR/2025/CRD-accelerometer-20250212/">https://www.w3.org/TR/2025/CRD-accelerometer-20250212/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2019/CR-accelerometer-20191212/">https://www.w3.org/TR/2019/CR-accelerometer-20191212/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2019/CR-accelerometer-20191212/">https://www.w3.org/TR/2019/CR-accelerometer-20191212/</a> (12 December 2019)
+                associated <a href="https://www.w3.org/mid/cfe-7282-088fbdf0be09f2b57f797db06f694f1729caf35d@w3.org">Call for Exclusion</a> 2019-12-12, opportunity until 2020-02-10
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/gyroscope/">Gyroscope</a>
@@ -468,19 +440,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/CRD-gyroscope-20230130/">https://www.w3.org/TR/2023/CRD-gyroscope-20230130/</a>
+              "https://www.w3.org/TR/2024/CRD-gyroscope-20241008/">https://www.w3.org/TR/2024/CRD-gyroscope-20241008/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2019/CR-gyroscope-20191212/">https://www.w3.org/TR/2019/CR-gyroscope-20191212/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2019/CR-gyroscope-20191212/">https://www.w3.org/TR/2019/CR-gyroscope-20191212/</a> (12 December 2019)
+                associated <a href="https://www.w3.org/mid/cfe-7283-6e029883c1d4de187688b7e7b2376708429e4061@w3.org">Call for Exclusion</a> 2019-12-12, opportunity until 2020-02-10
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/magnetometer/">Magnetometer</a>
@@ -491,24 +459,20 @@
               primary axes
             </p>
             <p class="draft-status">
-              <b>Draft state:</b> Candidate Recommendation
+              <b>Draft state:</b> Working Draft
             </p>
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-magnetometer-20230130/">https://www.w3.org/TR/2023/WD-magnetometer-20230130/</a>
+              "https://www.w3.org/TR/2025/WD-magnetometer-20250212/">https://www.w3.org/TR/2025/WD-magnetometer-20250212/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2018/CR-magnetometer-20180320/">https://www.w3.org/TR/2018/CR-magnetometer-20180320/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2018/CR-magnetometer-20180320/">https://www.w3.org/TR/2018/CR-magnetometer-20180320/</a> (20 March 2018)
+                associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2018Mar/0008.html">Call for Exclusion</a>  on 2018-03-20, opportunity until 2018-05-19 
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/orientation-sensor/">Orientation
@@ -525,24 +489,19 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-orientation-sensor-20230801/">https://www.w3.org/TR/2023/WD-orientation-sensor-20230801/</a>
+              "https://www.w3.org/TR/2024/WD-orientation-sensor-20240110/">https://www.w3.org/TR/2024/WD-orientation-sensor-20240110/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2022/11/das-wg-charter.html">https://www.w3.org/2022/11/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/">https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/">https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/</a> (12 December 2019)
+                associated <a href="https://www.w3.org/mid/cfe-7284-633d1fdb54a43b2328ca6f3da831e99cbdbf82cf@w3.org">Call for Exclusion</a> on 2019-12-12, opportunity until 2020-02-10
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href=
-            "https://www.w3.org/TR/orientation-event/">DeviceOrientation Event
-            specification</a>
+            "https://www.w3.org/TR/orientation-event/">Device Orientation and Motion</a>
           </dt>
           <dd>
             <p>
@@ -550,24 +509,20 @@
               orientation and motion of a hosting device
             </p>
             <p>
-              <b>Draft state</b>: Working Draft
+              <b>Draft state</b>: Candidate Recommendation Snapshot
             </p>
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-orientation-event-20230421/">https://www.w3.org/TR/2023/WD-orientation-event-20230421/</a>
+              "https://www.w3.org/TR/2025/CRD-orientation-event-20250212/">https://www.w3.org/TR/2025/CRD-orientation-event-20250212/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2016/CR-orientation-event-20160818/">https://www.w3.org/TR/2016/CR-orientation-event-20160818/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2024/CR-orientation-event-20241121/">https://www.w3.org/TR/2024/CR-orientation-event-20241121/</a> (21 November 2024)
+                associated <a href="https://www.w3.org/mid/cfe-14759-cde267815424afecf19a2b3ebcb768d7c4114106@w3.org">Call for Exclusion</a> on 2024-11-21, opportunity until 2025-01-20
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p class="issue">
               <b>Note:</b> This work is a joint deliverable with the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>.
             </p>
@@ -614,19 +569,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-device-posture-20230404/">https://www.w3.org/TR/2023/WD-device-posture-20230404/</a>
+              "https://www.w3.org/TR/2024/CR-device-posture-20241126/">https://www.w3.org/TR/2024/CR-device-posture-20241126/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2020/WD-screen-fold-20201217/">https://www.w3.org/TR/2020/WD-screen-fold-20201217/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2024/CR-device-posture-20241126/">https://www.w3.org/TR/2024/CR-device-posture-20241126/</a> (26 November 2024)
+                associated <a href="https://www.w3.org/mid/cfe-14777-d9199c607779991718e074ac9163efb8d7c9ad2c@w3.org">Call for Exclusion</a>  on 2024-11-26, opportunity until 2025-01-25
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2020/11/das-wg-charter.html">https://www.w3.org/2020/11/das-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
           </dd>
           <dt>
             <a href="https://www.w3.org/TR/contact-picker/">Contact Picker API
@@ -642,19 +593,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-contact-picker-20230308/">https://www.w3.org/TR/2023/WD-contact-picker-20230308/</a>
+              "https://www.w3.org/TR/2024/WD-contact-picker-20240708/">https://www.w3.org/TR/2024/WD-contact-picker-20240708/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/">https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/">https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/</a> (20 December 2022)
+                associated <a href="https://www.w3.org/mid/cfe-10967-4d942ed10f0be0cdaf52ca96068d4d43697c0943@w3.org">Call for Exclusion</a> on 2022-12-20, opportunity until 2023-05-19
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2022/11/das-wg-charter.html">https://www.w3.org/2022/11/das-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2022/11/das-wg-charter.html">https://www.w3.org/2022/11/das-wg-charter.html</a></p>
             <p class="issue">
               <b>Note:</b> This work is a joint deliverable with the <a href="https://www.w3.org/groups/wg/webapps">Web Applications Working Group</a>.
             </p>
@@ -673,19 +620,15 @@
             <p class="milestone"><b>Expected completion:</b> <i class="todo">[Q1–4 yyyy]</i></p>
             <p>
               <b>Adopted Draft</b>: <a href=
-              "https://www.w3.org/TR/2023/WD-compute-pressure-20230831/">https://www.w3.org/TR/2023/WD-compute-pressure-20230831/</a>
+              "https://www.w3.org/TR/2025/CRD-compute-pressure-20250521/">https://www.w3.org/TR/2025/CRD-compute-pressure-20250521/</a>
             </p>
+            <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
-              <b>Reference Draft</b>: <a href=
-              "https://www.w3.org/TR/2022/WD-compute-pressure-20221220/">https://www.w3.org/TR/2022/WD-compute-pressure-20221220/</a>
+              <b>Exclusion Draft:</b>
+                <a href="https://www.w3.org/TR/2025/CR-compute-pressure-20250424/">https://www.w3.org/TR/2025/CR-compute-pressure-20250424/</a> (24 April 2025)
+                associated <a href="https://www.w3.org/mid/cfe-15387-50fe7fd7a9ed069eeb61b2f1c8c71418ddd5493f@w3.org">Call for Exclusion</a> on 2025-04-24, opportunity until 2025-06-23
             </p>
-            <p><b>Exclusion Draft:</b> The <span class="todo">title, stable URL, and publication date of the most recent <a href='https://www.w3.org/policies/process/#exclusion-draft'>Exclusion Draft</a></span>.
-            <span class="todo">Exclusion period <b>began</b>; Exclusion period <b>ended</b>.</span> <span class='todo'>(this <a href="https://www.w3.org/2004/01/pp-impl/charter-assistant?wgid=32061">charter assistant</a> helps in producing the list. use the proper <a href='https://www.w3.org/2004/01/pp-impl/'>wgid</a>)</span>
-            <p><b>Exclusion Draft Charter:</b> The  <span class="todo">stable URL of the <a href='https://www.w3.org/policies/process/#exclusion-draft-charter'>Working Group charter</a></span> under which the most recent Exclusion Draft was published.
-            <p>
-              Produced under <b>Working Group Charter:</b> <a href=
-              "https://www.w3.org/2022/11/das-wg-charter.html">https://www.w3.org/2022/11/das-wg-charter.html</a>
-            </p>
+            <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
           </dd>
         </dl>
         </section>

--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -274,7 +274,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2016/CR-battery-status-20160707/">https://www.w3.org/TR/2016/CR-battery-status-20160707/</a> (7 July 2016)
+                <a href="https://www.w3.org/TR/2016/CR-battery-status-20160707/">https://www.w3.org/TR/2016/CR-battery-status-20160707/</a> (7 July 2016)<br>
                 associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Jul/0005.html">Call for Exclusion</a> on 2016-07-07, opportunity until 2016-09-05
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
@@ -297,7 +297,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a> (14 December 2017)
+                <a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a> (14 December 2017)<br>
                 associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Jul/0005.html">Call for Exclusion</a> on 2016-07-07, opportunity until 2016-09-05
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
@@ -323,7 +323,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a> (14 December 2017)
+                <a href="https://www.w3.org/TR/2017/CR-wake-lock-20171214/">https://www.w3.org/TR/2017/CR-wake-lock-20171214/</a> (14 December 2017)<br>
                 associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2016Jul/0005.html">Call for Exclusion</a> on 2016-07-07, opportunity until 2016-09-05
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
@@ -348,7 +348,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2019/CR-generic-sensor-20191212/">https://www.w3.org/TR/2019/CR-generic-sensor-20191212/</a> (12 December 2019)
+                <a href="https://www.w3.org/TR/2019/CR-generic-sensor-20191212/">https://www.w3.org/TR/2019/CR-generic-sensor-20191212/</a> (12 December 2019)<br>
                 associated <a href="https://www.w3.org/mid/cfe-7281-de5379e5d2ea5f48aa29d87ab75bf6813b0e39b9@w3.org">Call for Exclusion</a> on 2019-12-12, opportunity until 2020-02-10 
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
@@ -372,7 +372,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2012/WD-proximity-20121206/">https://www.w3.org/TR/2012/WD-proximity-20121206/</a> (6 December 2012)
+                <a href="https://www.w3.org/TR/2012/WD-proximity-20121206/">https://www.w3.org/TR/2012/WD-proximity-20121206/</a> (6 December 2012)<br>
                 associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2012Dec/0000.html">Call for Exclusion</a> on 2012-12-06, opportunity until 2013-02-04
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2011/07/DeviceAPICharter.html">https://www.w3.org/2011/07/DeviceAPICharter.html</a></p>
@@ -397,7 +397,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2018/CR-ambient-light-20180320/">https://www.w3.org/TR/2018/CR-ambient-light-20180320/</a> (20 March 2018)
+                <a href="https://www.w3.org/TR/2018/CR-ambient-light-20180320/">https://www.w3.org/TR/2018/CR-ambient-light-20180320/</a> (20 March 2018)<br>
                 associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2018Mar/0008.html">Call for Exclusion</a> on 2018-03-20, opportunity until 2018-05-19 
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
@@ -421,7 +421,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2019/CR-accelerometer-20191212/">https://www.w3.org/TR/2019/CR-accelerometer-20191212/</a> (12 December 2019)
+                <a href="https://www.w3.org/TR/2019/CR-accelerometer-20191212/">https://www.w3.org/TR/2019/CR-accelerometer-20191212/</a> (12 December 2019)<br>
                 associated <a href="https://www.w3.org/mid/cfe-7282-088fbdf0be09f2b57f797db06f694f1729caf35d@w3.org">Call for Exclusion</a> 2019-12-12, opportunity until 2020-02-10
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
@@ -445,7 +445,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2019/CR-gyroscope-20191212/">https://www.w3.org/TR/2019/CR-gyroscope-20191212/</a> (12 December 2019)
+                <a href="https://www.w3.org/TR/2019/CR-gyroscope-20191212/">https://www.w3.org/TR/2019/CR-gyroscope-20191212/</a> (12 December 2019)<br>
                 associated <a href="https://www.w3.org/mid/cfe-7283-6e029883c1d4de187688b7e7b2376708429e4061@w3.org">Call for Exclusion</a> 2019-12-12, opportunity until 2020-02-10
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
@@ -469,7 +469,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2018/CR-magnetometer-20180320/">https://www.w3.org/TR/2018/CR-magnetometer-20180320/</a> (20 March 2018)
+                <a href="https://www.w3.org/TR/2018/CR-magnetometer-20180320/">https://www.w3.org/TR/2018/CR-magnetometer-20180320/</a> (20 March 2018)<br>
                 associated <a href="https://lists.w3.org/Archives/Member/member-cfe/2018Mar/0008.html">Call for Exclusion</a>  on 2018-03-20, opportunity until 2018-05-19 
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">https://www.w3.org/2016/03/device-sensors-wg-charter.html</a></p>
@@ -494,7 +494,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2022/11/das-wg-charter.html">https://www.w3.org/2022/11/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/">https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/</a> (12 December 2019)
+                <a href="https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/">https://www.w3.org/TR/2019/CR-orientation-sensor-20191212/</a> (12 December 2019)<br>
                 associated <a href="https://www.w3.org/mid/cfe-7284-633d1fdb54a43b2328ca6f3da831e99cbdbf82cf@w3.org">Call for Exclusion</a> on 2019-12-12, opportunity until 2020-02-10
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2019/03/devices-sensors-wg-charter.html">https://www.w3.org/2019/03/devices-sensors-wg-charter.html</a></p>
@@ -519,7 +519,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2024/CR-orientation-event-20241121/">https://www.w3.org/TR/2024/CR-orientation-event-20241121/</a> (21 November 2024)
+                <a href="https://www.w3.org/TR/2024/CR-orientation-event-20241121/">https://www.w3.org/TR/2024/CR-orientation-event-20241121/</a> (21 November 2024)<br>
                 associated <a href="https://www.w3.org/mid/cfe-14759-cde267815424afecf19a2b3ebcb768d7c4114106@w3.org">Call for Exclusion</a> on 2024-11-21, opportunity until 2025-01-20
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
@@ -574,7 +574,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2024/CR-device-posture-20241126/">https://www.w3.org/TR/2024/CR-device-posture-20241126/</a> (26 November 2024)
+                <a href="https://www.w3.org/TR/2024/CR-device-posture-20241126/">https://www.w3.org/TR/2024/CR-device-posture-20241126/</a> (26 November 2024)<br>
                 associated <a href="https://www.w3.org/mid/cfe-14777-d9199c607779991718e074ac9163efb8d7c9ad2c@w3.org">Call for Exclusion</a>  on 2024-11-26, opportunity until 2025-01-25
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
@@ -598,7 +598,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/">https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/</a> (20 December 2022)
+                <a href="https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/">https://www.w3.org/TR/2022/WD-contact-picker-1-20221220/</a> (20 December 2022)<br>
                 associated <a href="https://www.w3.org/mid/cfe-10967-4d942ed10f0be0cdaf52ca96068d4d43697c0943@w3.org">Call for Exclusion</a> on 2022-12-20, opportunity until 2023-05-19
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2022/11/das-wg-charter.html">https://www.w3.org/2022/11/das-wg-charter.html</a></p>
@@ -625,7 +625,7 @@
             <p>Produced under <b>Working Group Charter:</b> <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>
             <p>
               <b>Exclusion Draft:</b>
-                <a href="https://www.w3.org/TR/2025/CR-compute-pressure-20250424/">https://www.w3.org/TR/2025/CR-compute-pressure-20250424/</a> (24 April 2025)
+                <a href="https://www.w3.org/TR/2025/CR-compute-pressure-20250424/">https://www.w3.org/TR/2025/CR-compute-pressure-20250424/</a> (24 April 2025)<br>
                 associated <a href="https://www.w3.org/mid/cfe-15387-50fe7fd7a9ed069eeb61b2f1c8c71418ddd5493f@w3.org">Call for Exclusion</a> on 2025-04-24, opportunity until 2025-06-23
             </p>
             <p><b>Exclusion Draft Charter:</b> Produced under Working Group Charter: <a href="https://www.w3.org/2024/02/das-wg-charter.html">https://www.w3.org/2024/02/das-wg-charter.html</a></p>


### PR DESCRIPTION
as title. /cc @w3c/w3c-group-43696-chairs , Notes:

- geolocation sensor is kept left per #731 
- we may need to bring Geolocation API into normative deliverables, how do you all think?
- [ ] need check of listed items against current WG deliverables (again, to secure)