### PR TITLE
[wg/webperf] to follow the charter template

### DIFF
--- a/2026/webperf-wg-charter.html
+++ b/2026/webperf-wg-charter.html
@@ -67,7 +67,7 @@
 
 
     <main>
-      <h1 id="title">[PROPOSED] Web Performance Working Group Charter</h1>
+      <h1 id="title">[DRAFT] Web Performance Working Group Charter</h1>
 
       <p class="mission">The <strong>mission</strong> of the <a href="https://www.w3.org/groups/wg/webperf">Web Performance Working Group</a> 
         is to provide methods to observe and improve aspects of application performance of user agent features and APIs.</p>
@@ -76,7 +76,7 @@
         <p class="join"><a href="https://www.w3.org/groups/wg/webperf/join">Join the Web Performance Working Group.</a></p>
       </div>
 
-  <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+  <p style="padding: 0.5ex; border: 1px solid green"> This draft charter is available
       on <a href="https://github.com/w3c/charter-drafts/blob/gh-pages/2026/webperf-wg-charter.html">GitHub</a>.
         Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue%20state%3Aopen%20%5Bwg%2Fwebperf%5D">issues</a>.
       </p> 


### PR DESCRIPTION
As per the notes in the [charter template](https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html?todo=@@), to distinguish the charter's status:
* replace DRAFT with PROPOSED when the AC review starts
* delete PROPOSED after AC review completed