### PR TITLE
[wg/das] removing three paragraphs from success criteria

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -787,55 +787,6 @@
           <li><a href="https://www.w3.org/TR/privacy-principles/">Privacy Principles</a>,</li>
           <li><a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.</li>
         </ul>
-
-        <p class="wg-specific">
-          APIs that cannot be demonstrated to be implementable securely within
-          the default browser context will not be released.
-        </p>
-        <p class="wg-specific">
-          The specifications produced by this WG must mitigate disclosure of
-          data when possible and seek meaningful user consent in other cases.
-          If the WG decides that one or more of its specifications cannot be
-          usefully implemented while simultaneously allowing users to
-          meaningfully consent to the use of sensitive data, it should not
-          advance those specifications.
-        </p>
-
-          <p class="wg-specific">
-            The Devices and Sensors WG will follow a <a href=
-            "https://www.w3.org/policies/testing/#test-as-you-commit">test as you
-            commit</a> approach to specification development, for
-            specifications in CR or above.
-            <i class="todo">Update text (esp. 2nd paragraph) to align with the newest text?</i>
-          </p>
-          <blockquote cite="https://www.w3.org/policies/testing/#test-as-you-commit">
-            <p>
-              All normative spec changes are generally expected to have a
-              corresponding pull request in <a href=
-              "https://github.com/web-platform-tests/wpt">web-platform-tests</a>,
-              either in the form of new tests or modifications to existing
-              tests, or must include the rationale for why test updates are not
-              required for the proposed update.
-            </p>
-            <p>
-              Typically, both pull requests (spec updates and tests) will be
-              merged at the same time. If a pull request for the specification
-              is approved but the other needs more work, add the '<a href=
-              "https://w3c.github.io/issue-metadata.html" rel="nofollow">needs
-              tests</a>' label or, in web-platform-tests, the '<a href=
-              "https://github.com/web-platform-tests/wpt/issues?utf8=%E2%9C%93&amp;q=label%3Astatus%3Aneeds-spec-decision%20">status:needs-spec-decision</a>'
-              label. Note that a test change that contradicts the specification
-              should not be merged before the corresponding specification
-              change.
-            </p>
-            <p>
-              If testing is not practical due to web-platform-tests
-              limitations, please explain why and if appropriate file an issue
-              with the '<a href=
-              "https://github.com/web-platform-tests/wpt/issues?utf8=%E2%9C%93&amp;q=label%3Atype%3Auntestable%20">type:untestable</a>'
-              label to follow up later.
-            </p>
-          </blockquote>
       </section>
       <section id="coordination" class="dependencies">
         <h2>


### PR DESCRIPTION
as title, some paragraphs are there as WG original text in former charter, but it is already covered by several Principle documents recently published. So, removing these, not to have duplicates.

already proposed via DM but please provide final approval, /cc @w3c/w3c-group-43696-chairs