### PR TITLE
[wg/extensions] Editorial nitpicking

### DIFF
--- a/2025/webextensions-wg.html
+++ b/2025/webextensions-wg.html
@@ -455,7 +455,7 @@
         <p>
           Each specification should contain separate sections detailing all
           known security and privacy implications for implementers, Web authors,
-          and end users.
+          and users.
         </p>
 
         <p>
@@ -682,7 +682,7 @@
           work.
         </p>
         <p>
-          The group may use a Member-confidential mailing list for
+          The group may use a Member-only mailing list for
           administrative purposes and, at the discretion of the Chairs and
           members of the group, for member-only discussions in special cases
           when a participant requests such a discussion.


### PR DESCRIPTION
 s/end users/users/ to align with the charter template.
s/Member-confidential/Member-only/ since it's the proper Process term.