### PR TITLE
Align with chairs charter draft

### DIFF
--- a/2026/webperf-wg-charter.html
+++ b/2026/webperf-wg-charter.html
@@ -466,7 +466,6 @@ the server to the user agent.</p>
   <ul>
     <li><a href="https://w3c.github.io/perf-security-privacy/">Security and Privacy considerations for Performance APIs</a></li>
     <li>Use cases documents to support development and exploration of performance-critical web platform features and APIs;</li>
-    <li>Primer or Best Practice documents to support web developers when designing applications with performance in mind;</li>
     <li>Developer and user guides for its normative specifications;</li>
     <li>Best practice document explaining how data is commonly gathered between the client and the server.</li>
   </ul>
@@ -513,7 +512,7 @@ interoperability can be verified by passing open test suites. In order to advanc
     </ul>
 
     <!-- Relevance and momentum -->
-	  <p> All new features should have expressions of interest from at least two potential implementors before being incorporated in a specification.</p>
+	  <p>New features that do not have support from at least two implementers will be incorporated into the draft specifications with an annotation of their experimental or optional status.</p>
 	</section>
 
       <section id="coordination">
@@ -572,7 +571,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           Participation
         </h2>
         <p>
-          To be successful, this Working Group is expected to have 9 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, are expected to maintain regular contributions of their time towards the Working Group. There is no minimum requirement for Participants.
+          To be successful, this Working Group is expected to have 9 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors for each specification. The Chairs and specification Editors are expected to maintain regular contributions of their time towards the Working Group. There is no minimum requirement for other Participants.
         </p>
         <p>
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.


### PR DESCRIPTION
@caribouW3 - this aligns the published charter draft with the chair's draft from https://github.com/w3c/web-performance/pull/67

@nicjansma - FYI