### PR TITLE
[wg/das] added i18n as coordination

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -1072,6 +1072,11 @@
             The Devices and Sensors Working Group will rely on incubation activities in WICG, 
             and adopt new proposals once they have matured through incubation.
           </dd>
+          <dt><a href="https://www.w3.org/groups/wg/i18n-core/">Internationalization Working Group</a></dt>
+          <dd>
+            There are internationalisation considerations in deliverables of the Devices and Sensors Working Group 
+            such as physical address representation in the Contact Picker API.
+          </dd>
         </dl>
         </section>
         <section>


### PR DESCRIPTION
from https://github.com/w3c/strategy/issues/530#issuecomment-4153917428

adding i18n WG to coordination, along with short text on relational.

@reillyeon @anssiko I suppose this part is some sort of symbolic (by means that i18n WG is joining to active/daily discussion of spec development, but giving relevant comments when requested), and can go w/o group wide solid consensus, but if you feel we need please start CfC within the DAS WG on this PR.

will merge around one+ weeks later, like 2026-05-15 or shortly later.