### PR TITLE
[wg/das] Adjust expected progress wording (resolves TAG feedback bullet point 1)

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -576,10 +576,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification;
-              however it will prefer to add new features to the
-              <a href="#device-orientation-and-motion">Device Orientation and Motion</a>
-              specification.
+              The Working Group will continue to
+              maintain the specification, but not add new features to it.
+              Instead, the Working Group will add new features to the
+              <a href="#device-orientation-and-motion">Device Orientation and
+              Motion</a> specification.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -644,10 +645,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification;
-              however it will prefer to add new features to the
-              <a href="#device-orientation-and-motion">Device Orientation and Motion</a>
-              specification.
+              The Working Group will continue to
+              maintain the specification, but not add new features to it.
+              Instead, the Working Group will add new features to the
+              <a href="#device-orientation-and-motion">Device Orientation and
+              Motion</a> specification.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -712,10 +714,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification;
-              however it will prefer to add new features to the
-              <a href="#device-orientation-and-motion">Device Orientation and Motion</a>
-              specification.
+              The Working Group will continue to
+              maintain the specification, but not add new features to it.
+              Instead, the Working Group will add new features to the
+              <a href="#device-orientation-and-motion">Device Orientation and
+              Motion</a> specification.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=


### PR DESCRIPTION
Addresses [TAG concern](https://github.com/w3ctag/design-reviews/issues/1187):

> We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the Device Orientation and Motion spec is in Baseline. It makes sense to maintain non-consensus specifications while websites switch over to equivalent consensus APIs, but the charter should commit to only adding new features to the consensus versions. If there's not enough consensus on the new features to incorporate them into the core Device Orientation and Motion spec, this WG could develop an extension specification that allows websites to mostly use the Baseline feature, with a few engine-specific extensions.