### PR TITLE
[wg/das] Remove haptics from DAS charter draft

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -512,8 +512,7 @@
             <p>
               <b>Expected progress:</b>
               The Working Group will update the specification to modern web
-              platform design principles and device haptics capabilities and
-              continue to solicit feedback.
+              platform design principles and continue to solicit feedback.
             </p>
             <p><b>Adopted Draft</b>: <a href="https://www.w3.org/TR/2025/CRD-vibration-20250212/">https://www.w3.org/TR/2025/CRD-vibration-20250212/</a> (12 February 2025)</p>
             <p>


### PR DESCRIPTION
Removed mention of device haptics capabilities from the Devices and Sensors WG charter draft. It was not my intention to create a scope conflict with the WebApps WG. 

Fixed #782.