### PR TITLE
[wg/das] Add standards position commitment (resolves TAG feedback bullet point 2)

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -236,6 +236,18 @@
           basis considering the requirements derived from real-world use cases.
         </p>
         <p>
+          For specifications not co-developed as Joint Deliverables with the
+          Web Applications Working Group, the WG will engage non-participating
+          browser engines for their standards positions, should they allow
+          requesting one. At key maturity-level transitions such as FPWD and
+          CR, the WG will request a position, allowing at least six weeks for
+          a response. Where a position exists, the WG will publish a public
+          disposition linking to it, responding to each substantive concern,
+          and recording how the concern was addressed or why it was not. The
+          disposition will be published before the specification advances to
+          its next maturity level.
+        </p>
+        <p>
           The WG will reuse existing security and privacy-focused web features
           and APIs developed in other groups where applicable. If the existing
           solutions do not provide the level of protection required, the WG


### PR DESCRIPTION
Addresses [TAG concern](https://github.com/w3ctag/design-reviews/issues/1187):

> We want to ensure that the other specifications fill clear user needs and are making appropriate tradeoffs between those user needs and any potential abuse of the APIs. In many WGs, we can rely on all 3 browser engines to check this, but since this WG does not currently include participation from all major browser engines, we're more concerned here. Could you add this goal to the charter for each of the specifications in that class?