### PR TITLE
[wg/das] Add per-spec plans (resolves TAG feedback bullet point 3)

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -254,6 +254,20 @@
         <h2>
           Deliverables
         </h2>
+        <p>
+          For each normative or tentative deliverable that is shipping in a
+          single browser engine, prototyped in a single browser engine, or
+          not implemented in any browser engine, the Expected Progress entry
+          for that deliverable follows this Plan template:
+        </p>
+        <ol>
+          <li>the current implementation status of the specification;</li>
+          <li>the next step per the Process if the Recommendation
+            advancement criterion (see <a href="#success-criteria">Success
+            Criteria</a>) has not been met by the end of this charter term, including an appropriate
+            status transition (for example, publication as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>, from which work may resume as a
+            Working Draft if a second implementation emerges).</li>
+        </ol>
         <section id="normative">
         <h3 id="rec-track">
           Normative Specifications
@@ -280,9 +294,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification and
-              work with engines that have not implemented this proposal to
-              refine a solution for sites to react to device low-power states.
+              The Battery Status API is shipping in a single engine
+              (Chromium/Blink). If a second implementation has
+              not shipped by default by the end of this charter term, the
+              Working Group will publish the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume as a Working
+              Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -313,7 +329,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification.
+              Compute Pressure is shipping in a single engine (Chromium/Blink). If a second implementation has not shipped by default
+              by the end of this charter term, the Working Group will publish
+              the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>.
+              Work may resume as a Working Draft if a second implementation
+              emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -414,8 +434,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification
-              while it awaits feedback from other implementers.
+              The Device Posture API is shipping in a single engine
+              (Chromium/Blink). If a second implementation has
+              not shipped by default by the end of this charter term, the
+              Working Group will publish the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume as a Working
+              Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -478,11 +501,14 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to collect feedback from the
-              community on the use cases for this API and may publish an
-              independent "System Wake Lock" specification to complete the
-              process of splitting "Wake Lock" into two separate
-              specifications.
+              The System Wake Lock API is prototyped in one engine
+              (Chromium/Blink) and shipping in none. The Working Group's
+              goal is for this specification to ship by default in at least
+              two independent, interoperable browser engines. If a second
+              implementation has not shipped by default by the end of this
+              charter term, the Working Group will publish the specification
+              as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume
+              as a Working Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -511,9 +537,14 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will update the specification to modern web
-              platform design principles and device haptics capabilities and
-              continue to solicit feedback.
+              The Vibration API is shipping in a single engine
+              (Chromium/Blink); Gecko removed support in Firefox 129 and
+              WebKit has never shipped. If a second
+              implementation has not shipped by default by the end of
+              this charter term, the Working Group will publish the
+              specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>.
+              Work may resume as a Working Draft if a second
+              implementation emerges.
             </p>
             <p><b>Adopted Draft</b>: <a href="https://www.w3.org/TR/2025/CRD-vibration-20250212/">https://www.w3.org/TR/2025/CRD-vibration-20250212/</a> (12 February 2025)</p>
             <p>
@@ -544,8 +575,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification as
-              infrastructure for future sensor APIs.
+              The Generic Sensor API is shipping in a single engine
+              (Chromium/Blink). If a second implementation has
+              not shipped by default by the end of this charter term, the
+              Working Group will publish the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume as a Working
+              Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -576,10 +610,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification;
-              however it will prefer to add new features to the
-              <a href="#device-orientation-and-motion">Device Orientation and Motion</a>
-              specification.
+              Accelerometer is shipping in a single engine (Chromium/Blink). If a second implementation has not shipped by default
+              by the end of this charter term, the Working Group will publish
+              the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>.
+              Work may resume as a Working Draft if a second implementation
+              emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -611,9 +646,14 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to collect feedback from the
-              community on the use cases for this API and may publish a new
-              Working Draft.
+              The Ambient Light Sensor is prototyped in one engine
+              (Chromium/Blink) and shipping in none. The Working Group's
+              goal is for this specification to ship by default in at least
+              two independent, interoperable browser engines. If a second
+              implementation has not shipped by default by the end of this
+              charter term, the Working Group will publish the specification
+              as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume
+              as a Working Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -644,10 +684,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification;
-              however it will prefer to add new features to the
-              <a href="#device-orientation-and-motion">Device Orientation and Motion</a>
-              specification.
+              Gyroscope is shipping in a single engine (Chromium/Blink). If a second implementation has not shipped by default
+              by the end of this charter term, the Working Group will publish
+              the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>.
+              Work may resume as a Working Draft if a second implementation
+              emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -678,9 +719,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to collect feedback from the
-              community on the use cases for this API and may publish a new
-              Working Draft.
+              Magnetometer is prototyped in one engine (Chromium/Blink) and
+              shipping in none. If a second implementation has
+              not shipped by default by the end of this charter term, the
+              Working Group will publish the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume as a Working
+              Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -712,10 +755,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to maintain the specification;
-              however it will prefer to add new features to the
-              <a href="#device-orientation-and-motion">Device Orientation and Motion</a>
-              specification.
+              Orientation Sensor is shipping in a single engine
+              (Chromium/Blink). If a second implementation has
+              not shipped by default by the end of this charter term, the
+              Working Group will publish the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume as a Working
+              Draft if a second implementation emerges.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=
@@ -746,9 +790,11 @@
             </p>
             <p>
               <b>Expected progress:</b>
-              The Working Group will continue to collect feedback from the
-              community on the use cases for this API and may publish a new
-              Working Draft.
+              Proximity Sensor is not implemented in any browser engine. If
+              the specification has not demonstrated adequate implementation
+              experience by the end of this charter term, the Working
+              Group will publish the specification as a <a href="https://www.w3.org/policies/process/#abandon-draft">Discontinued Draft</a>. Work may resume as a Working Draft if
+              implementations emerge.
             </p>
             <p>
               <b>Adopted Draft</b>: <a href=


### PR DESCRIPTION
Addresses [TAG concern](https://github.com/w3ctag/design-reviews/issues/1187):

> The [Vibration Council recommended](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations) that "the WG document the plan [to ship in multiple major browser engines] it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable." We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection.

Closes w3c/charter-drafts#781