### PR TITLE
[wg/das] proposed Team decision on TAG feedback bullet point 2

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -236,15 +236,15 @@
           basis considering the requirements derived from real-world use cases.
         </p>
         <p>
-          For specifications not co-developed as Joint Deliverables with the
-          Web Applications Working Group, the WG will engage non-participating
+          The WG will engage non-participating
           browser engines for their standards positions, should they allow
-          requesting one. At key maturity-level transitions such as FPWD and
-          CR, the WG will request a position, allowing at least six weeks for
+          requesting one. At key maturity-level transitions such as 
+          <a href="https://www.w3.org/policies/process/#first-wd">FPWD</a> and
+          <a href="https://www.w3.org/policies/process/#transition-cr">CR</a>, 
+          the WG will request a position, allowing at least six weeks for
           a response. Where a position exists, the WG will publish a public
-          disposition linking to it, responding to each substantive concern,
-          and recording how the concern was addressed or why it was not. The
-          disposition will be published before the specification advances to
+          disposition linking to it and responding to each substantive concern. 
+          The disposition will be published before the specification advances to
           its next maturity level.
         </p>
         <p>

--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -236,6 +236,18 @@
           basis considering the requirements derived from real-world use cases.
         </p>
         <p>
+          For specifications not co-developed as Joint Deliverables with the
+          Web Applications Working Group, the WG will engage non-participating
+          browser engines for their standards positions, should they allow
+          requesting one. At key maturity-level transitions such as FPWD and
+          CR, the WG will request a position, allowing at least six weeks for
+          a response. Where a position exists, the WG will publish a public
+          disposition linking to it, responding to each substantive concern,
+          and recording how the concern was addressed or why it was not. The
+          disposition will be published before the specification advances to
+          its next maturity level.
+        </p>
+        <p>
           The WG will reuse existing security and privacy-focused web features
           and APIs developed in other groups where applicable. If the existing
           solutions do not provide the level of protection required, the WG


### PR DESCRIPTION
r? @tidoust  @plehegar 

as discussed (Tue; thought to update through #808 but gave up with/via suggested changes - opening new PR). 

to be included into relation of decision, and disposition of comments, as follows:

- the Team modify the TAG proposed text to include a change suggested by Anssi to remove specifically mention to WebApps, since it is too biased and unbalanced mention of specific another WG where joint deliverables program is not limited to single target WG.
- the Team modify the TAG proposed text to make maturity level clear with adding a link to the Process