### PR TITLE
[wg/das] Add disposition of comments for DAS WG proposed charter

### DIFF
--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -7,24 +7,20 @@ Comments were received through:
 
 - [w3c/strategy #530](https://github.com/w3c/strategy/issues/530) — Strategy funnel issue (horizontal reviews)
 - [w3ctag/design-reviews #1187](https://github.com/w3ctag/design-reviews/issues/1187) — TAG review
-- [Issues](https://github.com/w3c/charter-drafts/issues?q=is%3Aissue+[wg%2Fdas]) and [PRs](https://github.com/w3c/charter-drafts/pulls?q=is%3Apr+%5Bwg%2Fdas%5D) to [w3c/charter-drafts](https://github.com/w3c/charter-drafts/) repository
+- [Issues](https://github.com/w3c/charter-drafts/issues?q=is%3Aissue+[wg%2Fdas]) and [pull requests](https://github.com/w3c/charter-drafts/pulls?q=is%3Apr+%5Bwg%2Fdas%5D) (PRs) in [w3c/charter-drafts](https://github.com/w3c/charter-drafts/) repository
 
 ## Executive summary
 
-All comments received during the charter refinement phase of the Devices and Sensors Working Group charter 
-have been discussed, and some resulted to charter changes, some are marked as continuing discussion for 
-later discussion for entire W3C strategy or to allow the AC to weigh in discussion,  
-and some have not been rejected without change made. 
+The charter refinement phase for the Devices and Sensors Working Group charter triggered substantive discussions between the Working Group, the TAG, other Members and the Team. This disposition of comments only tracks high-level comments. Please check the above channels for details. Of the 16 high-level comments received:
 
-Of the 19 comments (in category) received:
+* 4 were Accepted and the proposed text integrated in the draft charter;
+* 4 were Accepted with amended text or partially accepted;
+* 6 were Noted, without leading to further charter changes;
+* 2 were Declined.
 
-* 5 were Accepted, and resulted in charter changes.
-* 3 were Accepted with amended text, and resulted in charter changes.
-* 6 were Noted, without requiring charter change.
-* 1 was Deferred, to later discussion for entire W3C strategy.
-* 1 was Declined, to allow the AC to weigh in.
-* 2 were Rejected without change mage.
-* 1 was Won't fix.
+Some of the accepted changes do not have Working Group consensus. In general, the Chairs of the DAS Working Group note that the group strictly follows Process requirements, and that some of the proposed changes would better be brought to the Process document, within the Process Community Group and the Advisory Board, to ensure cohesion, separation of concerns and broad membership support for the procedures that govern Working Groups.
+
+Other changes such as the inclusion of 5 peripheral API specifications as tentative deliverables trigger additional concerns, about the right venue for the development of the specifications and support across implementers. The specifications were added to the draft charter to give the Advisory Committee the opportunity to weigh in during their review.
 
 ## Horizontal reviews
 
@@ -40,10 +36,7 @@ by Ruoxi Ran, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues
 
 by Simone Onofri, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-3848628218)
 
-**Response** The DAS WG appreciate the comment, and described situation in 
-[w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-4569236084).
-
-> The group does not maintain a single list of main security and privacy threats. While there are some common themes among APIs (e.g. there are some threats common to sensor APIs that are captured in the [Generic Sensors specification](https://w3c.github.io/sensors/#security-and-privacy)) putting something together that covers all the specifications under the charter (e.g. [Contact Picker](https://www.w3.org/TR/contact-picker/#privacy), which has a very different set of considerations than sensor APIs) would risk creating overlap with W3C-level security and privacy guidance such as the [Threat Model for the Web](https://www.w3.org/TR/threat-model-web/) and the TAG's [Security and Privacy Questionnaire](https://www.w3.org/TR/security-privacy-questionnaire/). To the extend where it would be valuable to collect common security and privacy guidance in a single place, I think the Generic Sensors example is a good compromise between not duplicating high-level web platform design guidance and gathering domain-specific considerations.
+**Response:** No changes were made to the draft charter. The DAS Working Group does not maintain a single list of main security and privacy threats. While there are some common themes among APIs (e.g. there are some threats common to sensor APIs that are captured in the [Generic Sensors specification](https://w3c.github.io/sensors/#security-and-privacy)), putting something together that covers all the specifications under the charter (e.g. [Contact Picker](https://www.w3.org/TR/contact-picker/#privacy), which has a very different set of considerations than sensor APIs) would risk creating overlap with W3C-level security and privacy guidance such as the [Threat Model for the Web](https://www.w3.org/TR/threat-model-web/) and the TAG's [Security and Privacy Questionnaire](https://www.w3.org/TR/security-privacy-questionnaire/). To the extent where it would be valuable to collect common security and privacy guidance in a single place, the Generic Sensors example is a good compromise between not duplicating high-level web platform design guidance and gathering domain-specific considerations.
 
 ### Privacy - Noted
 
@@ -61,79 +54,48 @@ by pes10k, [w3cping/privacy-request #192 comment](https://github.com/w3cping/pri
 
 by Atsushi Shimono, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-4153917428)
 
-**Response** Internationalization WG has been added to the Coordination section by [w3c/charter-drafts PR #804](https://github.com/w3c/charter-drafts/pull/804)
+**Response:** Internationalization WG was added to the Coordination section through [w3c/charter-drafts PR #804](https://github.com/w3c/charter-drafts/pull/804).
 
 ## TAG review 
 
-### 5 points of concerns
+The TAG raised 5 main points of concerns ([w3ctag/design-reviews #1187 comment](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)), and provided pull requests for 4 of these points.
 
-TAG raised 5 points of concerns ([w3ctag/design-reviews #1187 comment](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)), 
-and provided PRs for 4 points.
+*Note:* A number of intermediary issues, pull requests and comments were made while attempting to resolve these concerns. This disposition of comments sticks to high-level comments for readibility. Please check the [Strategy issue](https://github.com/w3c/strategy/issues/530), [TAG design review issue](https://github.com/w3ctag/design-reviews/issues/1187) and [draft charter repository](https://github.com/w3c/charter-drafts) for details.
 
-#### Specifications with one implementation - Accepted with amendment made
+### Specifications with one implementation - Accepted with amended text, no WG consensus
 
 > We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec is in Baseline. It makes sense to maintain non-consensus specifications while websites switch over to equivalent consensus APIs, but the charter should commit to only adding new features to the consensus versions. If there's not enough consensus on the new features to incorporate them into the core [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec, this WG could develop an extension specification that allows websites to mostly use the Baseline feature, with a few engine-specific extensions.
 
-**Response**
-The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
-the WG discussed on additional change over the PR but did not reach WG consensus. 
+The TAG provided [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806) to address this concern.
 
-The Working Group has added expected progress status for these deliverables to the charter and 
-updated the "Status of this Document" section to provide clarity for developers and implementers.
+**Response:** Expected progress for the deliverables was added to the charter. The "Status of this Document" sections of these deliverables were also updated to clarify the implementation status for developers and implementers. Additionally, the proposal from the TAG was integrated in the draft charter, with amended text to call out the possibility to work on security and privacy enhancements, through [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818). This update does not have consensus in the DAS WG.
 
-**Resolution** 
-And the draft charter has been updated following TAG proposal with adding amended text 
-as `including for security and privacy enhancements`
-to enable modification of adding new feature specifically related to security and privacy enhancements, 
-at [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818), 
-
-#### Involvement of multiple implementers - Accepted with amendment made
+### Involvement of multiple implementers - Accepted with amended text, no WG consensus
 
 > We want to ensure that the other specifications fill clear user needs and are making appropriate tradeoffs between those user needs and any potential abuse of the APIs. In many WGs, we can rely on all 3 browser engines to check this, but since this WG does not currently include participation from all major browser engines, we're more concerned here. Could you add this goal to the charter for each of the specifications in that class? We see, for example, https://github.com/w3c/vibration/issues/45 to do this for Vibration, but it would be good to use the charter to ensure it gets done.
 
-**Response**
-The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
-the WG discussed on additional change over the PR, but did not resolved. 
+The TAG provided [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808) to address this comment.
 
-The Working Group is committed to making appropriate tradeoffs between use cases and risks of abuse, as demonstrated by productive collaborations with privacy and security researchers and horizontal groups. This is codified in the Motivation and Background section.
+**Response:** The proposal from the TAG was integrated in the draft charter (with minor text adjustments), through [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821). This change does not have consensus in the DAS WG though. The WG chairs note that the WG is committed to making appropriate tradeoffs between use cases and risks of abuse, as demonstrated by productive collaborations with privacy and security researchers and horizontal groups, and as codified in the Motivation and Background section in the draft charter, and that the WG continues to engage with non-participating browser engines as appropriate per the W3C Process.
 
-The Working Group continues to engage with non-participating browser engines as appropriate per the W3C Process.
-
-**Resolution**
-The draft charter has been updated following TAG proposal with integrating a change suggested by Anssi 
-to remove specifically mention to WebApps, and with adding links to the Process for making maturity level used in text clear, 
-by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
-
-#### Vibration API council concern - Accepted with amendment made
+### Vibration API council concern - Accepted with amended text, no WG consensus
 
 > The [Vibration Council recommended](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations) that "the WG document the plan [to ship in multiple major browser engines] it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable." We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection.
 
-Similar comments have been added to w3c/strategy #530, such as 
+Similar comments were made in the Strategy issue, including
 [comment](https://github.com/w3c/strategy/issues/530#issuecomment-3917515554), 
 [comment](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777),
 and [comment](https://github.com/w3c/strategy/issues/530#issuecomment-4210649633) by Marcos Cáceres. 
 
-**Response**
-The DAS WG resolved to add new implementation report for recently started Recommendation track specification 
-from Candidate Resommendation Snapshot by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55). 
+The TAG proposed [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809), which goes beyond the Vibration API specification to cover all deliverables shipping in a single browser engine.
 
-The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
-to add text not limited to the Vibration specification, but even further in relateion to TAG point 1, 
-the WG did not reached a concensus to accept or reject the PR.
+**Response:** The proposal from the TAG was integrated in the draft charter, with amended text to making transition back to incubation possible for specifications that could end up being published as discontinued, through [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819). The WG disagrees with this change. The WG Chairs note that the WG follows all W3C Process requirements when transitioning its deliverables from one maturity stage to another, and that the proposed changes would better be brought to the Process document itself through the Process Community Group and the Advisory Board.
 
-The Working Group continues to follow the W3C Process when transitioning its deliverables from one maturity stage to another.
+Also note that a new implementation report was created for the Vibration API specification, as recommended by the Council, through [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55).
 
-The process changes drafted by the TAG are in the purview of the Process CG and the Advisory Board, to be discussed therein as appropriate. The Working Group does not adopt the proposed changes to the charter to ensure cohesion, separation of concerns and broad membership support for the procedures that govern the Working Groups.
+### Support level in status section of specification - Accepted
 
-**Resolution**
-The draft charter has been updated following TAG porposal 
-with adding amended text to enable bringing specifications into CG as incubation along with publication as Discontinued Draft, 
-for making path clearer to continue incubation but not as completed end state, 
-by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819).
-
-#### Support level in status section of specification - Accepted
-
-> We would like the WG to find a way to signal the expected support level for each specification. There's some discomfort on the TAG with using the same spec status?Candidate Recommendation?for all of:
+> We would like the WG to find a way to signal the expected support level for each specification. There's some discomfort on the TAG with using the same spec status "Candidate Recommendation" for all of:
 > * deprecated specs that are being maintained while websites migrate to a consensus replacement;
 > * features that are stable in one engine but opposed by the others;
 > * "living" consensus specs that never intend to advance to Recommendation; and
@@ -141,95 +103,23 @@ by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819).
 > 
 > At the same time, we recognize that this is the only status the Process defines for patent protection of these kinds of specifications. At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that _developers reading a specification can tell at a glance which kind of document they're reading_.
 
-In addition to concern raised in TAG comment, several comments to w3ctag/design0reviews and w3c/strategy 
-has been made along with PRs to the DAS WG repositories by Marcos Cáceres, 
-([first](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4159936835), 
-and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4163174410) at w3ctag/design-reviews #1187, 
-and the same text posted as 
-[first](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174) and [second](https://github.com/w3c/strategy/issues/530#issuecomment-4163144358)
-at w3c/strategy #530), and PRs have been closed without merging. 
+Several comments and associated pull requests were raised on similar grounds in the discussion that followed in the TAG review issue, the strategy issue, and the draft charter's repository, including [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770) by Reilly Grant, and [w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780) by Marcos Cáceres.
 
-In parallel, issue [w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780) has been raised by Marcos Cáceres to track this concern, 
-and the draft DAS WG charter has been edited to include inplementation status and 
-expected progress by [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770).
+The TAG prepared [pull requests](https://github.com/w3c/strategy/issues/530#issuecomment-4544003815) to add implementation status notes to the Status of this Document sections of individual specifications.
 
-**Response** Accepted through 10 PRs.
+**Response:** The pull requests prepared by the TAG to update the specifications were merged. The draft charter was also updated through [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770) to convey the implementation status of the group's deliverables (see also the response from the previous comment).
 
-The TAG opened 10 PRs to specifications, and all merged by the WG, 
-Christian Liebel confirmed [this point 4 has been resolved with set of PRs](https://github.com/w3c/strategy/issues/530#issuecomment-4549836034).
+Implementation status and standard positions of the different specifications are also maintained in [the WG's wiki](https://www.w3.org/wiki/DAS/Implementations), which also links to [wpt.fyi](https://wpt.fyi/) for test results. These resources are referenced from the specification headers, as proposed by the TAG.
 
-* https://github.com/w3c/sensors/pull/494
-* https://github.com/w3c/magnetometer/pull/78
-* https://github.com/w3c/device-posture/pull/173
-* https://github.com/w3c/proximity/pull/63
-* https://github.com/w3c/compute-pressure/pull/319
-* https://github.com/w3c/accelerometer/pull/85
-* https://github.com/w3c/vibration/pull/65
-* https://github.com/w3c/gyroscope/pull/66
-* https://github.com/w3c/orientation-sensor/pull/87
-* https://github.com/w3c/ambient-light/pull/93
-
-Also the group maintains implementation status and standards positions in its 
-[wiki](https://www.w3.org/wiki/DAS/Implementations) and refers to 
-[wpt.fyi](https://wpt.fyi/) for test results. 
-These resources are referenced from the specification headers, as proposed by the TAG.
-
-
-#### Web Serial in tentative deliverables - Declined
+### Web Serial in tentative deliverables - Declined
 
 > We're concerned by the appearance of Web Serial in the [Tentative Deliverables](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html#tentative). At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead.
 
-In addition to this concern, 
-[additional comment]((https://github.com/w3c/strategy/issues/530#issuecomment-4380513758)) made by Marcos Cáceres to expand 
-concern over other newly added tentative deliverables, and 
-issue [w3c/charter-drafts #783](https://github.com/w3c/charter-drafts/issues/783) has been opened by Marcos Cáceres 
-which has [marked as not a TAG consensus comment by Jeffrey Yasskin](https://github.com/w3c/charter-drafts/issues/783#issuecomment-4171422602).
+The concern about the venue for this spec was also raised as W3C Member by Marcos Cáceres both in [the Strategy issue]((https://github.com/w3c/strategy/issues/530#issuecomment-4380513758)) and the [draft charter repository](https://github.com/w3c/charter-drafts/issues/783).
 
-**Response** 
-The group has consensus to take up Mozilla's proposal to add Web Serial and other related specifications as a Tentative Deliverable in this Working Group. We also note that Mozilla has also started a parallel effort to create a WHATWG workstream for peripheral APIs. This may offer an alternative path for a forum that all implementers are comfortable joining.
+**Response:** Additional peripheral APIs were proposed for addition in the meantime by Mozilla, see below for details. Also these APIs do not have support from all implementers, multiple implementers expressed support for them. No change were made for Web Serial, which is still listed as a tentative deliverable in the draft charter.
 
-Conversation held in [email thread](https://lists.w3.org/Archives/Public/www-archive/2026May/0000.html), 
-no conclusion has made. 
-
-### Other feedbacks on TAG review
-
-#### Address TAG review and Council recommendation feedback - Rejected
-
-> This PR applies the charter text suggestions posted in #770 (comment), addressing outstanding TAG review and W3C Council concerns. It is intended to be merged into PR #770 or land alongside it.
-> 
-> ## Changes
-> 
-> **Success Criteria — SotD signaling commitment** (addresses TAG charter concern, w3ctag/design-reviews#1187):
-> Adds three paragraphs committing the WG to: signal implementation status and trajectory in each spec's SotD; clearly label the role of single-engine specs; and review limited-support specs at least annually with publicly documented outcomes. Closes #780.
-> 
-> **Vibration — Expected progress** (addresses TAG charter concern + Council recommendation):
-> Replaces the vague "device haptics capabilities" text with a concrete commitment to publish the Council-recommended plan before AC review, with a visible `<i class="todo">` placeholder URL that must be filled in before the charter proceeds to AC review. Also requires the updated implementation report (w3c/vibration#33) to be publicly available before AC review opens. Coordinates haptics work with the Web Applications WG. Addresses #781, #782.
-> 
-> **Generic Sensor — Expected progress**:
-> Removes "infrastructure for future sensor APIs" framing. Adds commitment not to charter new Generic Sensor-derived deliverables without first documenting the architectural rationale relative to single-layer API alternatives. HTML comment in source notes the grounding and TAG context.
-> 
-> **Ambient Light Sensor + Proximity Sensor — Expected progress**:
-> Replaces vague "collect feedback and may publish a WD" with: proactively seek published implementer positions from non-participating engines, publish a summary of responses (including non-responses), and document a trajectory decision publicly.
-> 
-> ## Tracking issues
-> 
-> - #780 — SotD signaling commitment
-> - #781 — Vibration Council plan before AC review
-> - #782 — Vibration haptics scope conflict with WebApps WG
-> - #783 — Web Serial venue (not addressed in this PR — tracked separately)
-> 
-> cc @reillyeon @jyasskin @anssiko @himorin
-
-by Marcos Cáceres, [w3c/charte-drafts PR #784](https://github.com/w3c/charter-drafts/pull/784)
-
-**Resolution** Jeffrey Yasskin noted on this change that 
-`Here are my current thoughts on the proposal in this PR. This is not TAG consensus—it's just me so far. 
-We'll be discussing this in a TAG breakout later today, and hopefully we can report some more-unanimous position after that.`, 
-and this change has been closed without integrating per other changes proposed by the TAG in consensus 
-([w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808)
-and [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809)).
-
-#### Flagging design review concerens - Noted
+### Flagging design review concerns - Noted
 
 In parallel to 5 points of concerns, the TAG made a comment in the same post as:
 
@@ -240,63 +130,17 @@ to come up in future design reviews for the individual specifications:
 > * The Generic Sensor architecture seems overcomplicated overall. In reviews of features that use it, we'd appreciate some justification for why that architecture is better than defining APIs in a single layer, as [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) does.
 > * Are the signals in the Battery API still the right ones to help websites help users achieve their goals? Would a "please reduce power use" signal be sufficient, with the UA in charge of deciding how the precise battery level and charging state contribute to that signal?
 
-**Response** The DAS WG noted these comments and continue onversation during further design review over each specification.
+**Response:** These comments were noted by the DAS Working Group.
 
 ## Feedback provided to w3c/charter-drafts
 
-### Peripheral APIs
+### Peripheral APIs - Accepted
 
-Before submission by Mozilla to [whatwg/sg PR #264](https://github.com/whatwg/sg/pull/264/), 
-three specifications (out of five listed in whatwg/sg PR #264) has been proposed to be included into tentative deliverables. 
+Mozilla noted [support for Web Serial](https://github.com/w3c/charter-drafts/issues/771), and requested the [addition of WebUSB](https://github.com/w3c/charter-drafts/issues/772) and the [addition of Web Bluetooth](https://github.com/w3c/charter-drafts/issues/773) as [Tentative Deliverables](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html#tentative). In parallel, Mozilla also proposed the creation of a [Peripheral APIs WHATWG workstream](https://github.com/whatwg/sg/pull/264/) with the WebNFC and WebHID specifications. The possible creation of the workstream at WHATWG is still under consideration as this disposition of comments is written.
 
-#### Proposals raised by Mozilla - Accepted
+**Response:** Following discussions with implementers, the DAS WG and Web Applications WG co-chairs who indicated that the Web Applications WG is unable to accept any more specifications at this time, the draft charter now lists all 5 peripheral APIs (Web Bluetooth, WebHID, WebNFC, Web Serial, WebUSB) as tentative deliverables (to be developed solely by the DAS WG). Should the WHATWG workstream be created, the expectation is that the WG would not adopt these tentative deliverables. The peripheral APIs do not have support from all implementers, and Marcos Cáceres noted in particular [in a PR comment](https://github.com/w3c/charter-drafts/pull/786#issuecomment-4348603681) that WebKit has published *oppose* positions on Web Serial, WebUSB and Web Bluetooth.
 
-**Resolution**
-The draft charter has been updated to include all three specifications proposed by issues to w3c/charter-drafts, 
-and extended to 2 additional deliverables to allow the AC to weigh in, 
-by PRs [w3c/charter-drafts PR #786](https://github.com/w3c/charter-drafts/pull/786) and 
-[w3c/charter-drafts #820](https://github.com/w3c/charter-drafts/pull/820). 
-We note disagreement from Apple on this resolution. 
-
-These deliverables are not listed as joint deliverables with the Web Applications WG, 
-by change made at [w3c/charter-drafts PR #812](https://github.com/w3c/charter-drafts/pull/812) following 
-issue [w3c/charter-drafts #810](https://github.com/w3c/charter-drafts/issues/810) by Léonie Watson.
-
-##### Web Serial API
-
-> Can Web Serial be moved from “tentative deliverable” to “deliverable” given Mozilla has announced an intent to prototype which would make two implementations?
-> 
-> Here's Mozilla’s intent to prototype: https://groups.google.com/a/mozilla.org/g/dev-platform/c/EDLTASS4Zik/m/LXJRL6yFCQAJ
-> 
-> We prefer to keep the existing note in the listing of the deliverable: "Note: This work may turn into a joint deliverable with the Web Applications Working Group."
-
-by Haik Aftandilian, [w3c/charter-drafts #771](https://github.com/w3c/charter-drafts/issues/771)
-
-##### WebUSB
-
-> We (Mozilla Firefox) are considering the WebUSB API ([Firefox bug 2022432](https://bugzilla.mozilla.org/show_bug.cgi?id=2022432)) and thus request adding the WebUSB API in the DAS WG charter "Tentative Deliverables" as follows:
-> 
-> [WebUSB API](https://wicg.github.io/webusb/)
-> An API for reading and writing from a USB device through script.
-> Draft state: Draft Community Group Report
-> Adopted Draft: [Adopted from WICG](https://wicg.github.io/webusb/)
-> Note: This work may turn into a joint deliverable with the [Web Applications Working Group](https://www.w3.org/groups/wg/webapps).
-
-by Haik Aftandilian, [w3c/charter-drafts #772](https://github.com/w3c/charter-drafts/issues/772)
-
-##### Web Bluetooth
-
-> We (Mozilla Firefox) are considering the Web Bluetooth API ([Firefox bug 2022433](https://bugzilla.mozilla.org/show_bug.cgi?id=2022433)) and thus request adding the Web Bluetooth API in the DAS WG charter "Tentative Deliverables" as follows:
-> 
-> [Web Bluetooth API](https://webbluetoothcg.github.io/web-bluetooth/)
-> An API to discover and communicate with devices over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT).
-> Draft state: Draft Community Group Report
-> Adopted Draft: [Adopted from Web Bluetooth Community Group](https://webbluetoothcg.github.io/web-bluetooth/)
-> Note: This work may turn into a joint deliverable with the [Web Applications Working Group](https://www.w3.org/groups/wg/webapps).
-
-by Haik Aftandilian, [w3c/charter-drafts #773](https://github.com/w3c/charter-drafts/issues/773)
-
-#### Implementation across platform families - Noted
+### Implementation across platform families - Noted
 
 > Posting as W3C Member (not TAG Member).
 > 
@@ -326,13 +170,10 @@ by Haik Aftandilian, [w3c/charter-drafts #773](https://github.com/w3c/charter-dr
 
 by Marcos Cáceres, [w3c/charter-drafts #799](https://github.com/w3c/charter-drafts/issues/799)
 
-**Response**
-The DAS WG describes current implementation situation for sensor APIs, and demonstrated possibility of 
-implementation accross multiple platforms like over CPUs and SoCs.
+**Response:** Proposals from the TAG that were integrated in the draft charter add constraints on deliverables shipping in a single browser engine. Additional support for some of the deliverables mentioned was provided during the charter refinement period. No further changes were made to the draft charter.
 
-The draft DAS WG charter has been update to consider of single implementation status following change proposed by the TAG.
 
-#### Potential security risk on sandbox escape via device APIs - Noted
+### Potential security risk on sandbox escape via device APIs - Noted
 
 > Posting as W3C Member (not TAG Member).
 > 
@@ -376,16 +217,9 @@ The draft DAS WG charter has been update to consider of single implementation st
 
 by Marcos Cáceres, [w3c/charter-drafts #798](https://github.com/w3c/charter-drafts/issues/798)
 
-**Response** In specifications in CG space, these attack scenarios are largely acknowledged by the 
-"Security Considerations" sections of these specifications.
+**Response:** The specifications were added as tentative deliverables to the draft charter. These attack scenarios are largely acknowledged by the "Security Considerations" sections of these specifications. Wide review on these specifications may also help detect and address more security risks.
 
-**Resolution** Five specifications of Peripheral APIs has been kept within the draft charter, to allow AC to weigh in. 
-We note this disagreement on this resolution. 
-
-
-### Comments related to implementation status and language
-
-#### Implementation report and WG plan for Vibration API - Won't fix
+### Implementation report and WG plan for Vibration API - Partially accepted
 
 > **Context:** This issue tracks concerns from both the W3C Council report and the TAG review of the 2026 DAS WG charter.
 > 
@@ -413,72 +247,18 @@ We note this disagreement on this resolution.
 
 by Marcos Cáceres, [issue raised as w3c/charter-drafts #781](https://github.com/w3c/charter-drafts/issues/781)
 
-**Response** Part of concern resolved by implementation report has been added by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55).
+**Response:** The implementation report part was resolved through [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55). Integration of the text proposed by the TAG to address a similar councern (see TAG Vibration API council concern above) creates a plan for the Vibration API and other WG deliverables. There is no WG consensus on the plan though.
 
-No conclusion has been made in consensus for specification update plan of Vibration specification. 
-
-### Other comments
-
-#### Wrong listing of geolocation specification - Accepted
+### Wrong listing of geolocation specification - Accepted
 
 > GeoLocation is under active development, so it should be moved out of the maintenance section into the normative specs section.
-> 
-> @himorin , @anssiko, @reillyeon, @w3c/marcomm, @siusin  
 
 by Léonie Watson, [w3c/charter-drafts #811](https://github.com/w3c/charter-drafts/issues/811)
 
-**Response** Error fixed by [w3c/charter-drafts PR #813](https://github.com/w3c/charter-drafts/pull/813)
+**Response:** Error fixed by [w3c/charter-drafts PR #813](https://github.com/w3c/charter-drafts/pull/813)
 
-#### Mentioning Haptics in DAS charter
+### Adding Haptics to the DAS charter - Declined
 
-##### Remove `Haptics` from description of Vibration API - Accepted
+A proposal was made by Microsoft to add the [Web Haptics API](https://github.com/w3c/charter-drafts/pull/795). Other related comments were made to drop or clarify the scope of the DAS WG charter with regards to haptics, which is already in scope of the Web Applications WG, see [comment by Marcos](https://github.com/w3c/charter-drafts/issues/782), and [pull request by Anssi Kostiainen](https://github.com/w3c/charter-drafts/pull/816).
 
-> **Note:** This concern is raised by @marcoscaceres in his personal capacity as a W3C member, not on behalf of the TAG. The TAG review (w3ctag/design-reviews#1187) was published before PR #770 introduced this specific language.
-> 
-> PR #770 adds the following "Expected progress" text for Vibration:
-> 
-> > "The Working Group will update the specification to modern web platform design principles and **device haptics capabilities** and continue to solicit feedback."
-> 
-> The phrase "device haptics capabilities" is problematic. The current Web Applications WG 2026 charter (https://www.w3.org/2026/01/webappswg-charter-2026.html) explicitly includes in its scope:
-> 
-> > "Haptic input devices and their emitted events and/or data."
-> 
-> And lists as a WICG deliverable:
-> 
-> > "Haptics — An API allowing web applications to interface with haptic actuators, such as vibration motors found on gamepad controllers, and potentially other devices that provide haptic feedback."
-> 
-> Haptics is not listed as a joint deliverable between DAS and WebApps in either the current WebApps charter or the DAS draft charter. WebApps and the Immersive Web CG are also actively exploring related work (see https://github.com/immersive-web/proposals/issues/92).
-> 
-> The DAS charter text must either:
-> 1. Confirm that Vibration remains a minimal primitive and explicitly remove the "device haptics capabilities" language, or
-> 2. Explicitly establish a joint deliverable arrangement with the Web Applications WG for any haptics-related work, with a clear statement of scope differentiation.
-> 
-> As written, the language signals unilateral expansion into an area that is already in scope of another WG, without a coordination model.
-> 
-> Additionally, the TAG review (charter-affecting section) specifically called out Vibration for needing better documentation of user needs and tradeoffs, citing w3c/vibration#45. That issue ("Create an explainer") remains open with no progress.
-> 
-> Related: #770, w3ctag/design-reviews#1187, w3c/vibration#45, https://github.com/immersive-web/proposals/issues/92
-
-by Marcos Cáceres, [issue raised as w3c/charter-drafts #782](https://github.com/w3c/charter-drafts/issues/782)
-
-**Response** The draft DAS charter has been updated by [w3c/charter-drafts #807](https://github.com/w3c/charter-drafts/pull/807). 
-
-##### Clarify haptics scope - Rejected
-
-Adding `semantic haptic feedback` into Scope, and `Gamepad haptics are out of scope for this WG` into Out of Scope
-
-by Anssi Kostiainen, [w3c/charter-drafts PR #816](https://github.com/w3c/charter-drafts/pull/816)
-
-**Resolution** This change has not been integrated into the draft DAS charter.
-
-##### Adding Web Haptics API, Revise DAS WG charter with a new deliverable proposed by Microsoft - Deferred
-
-Adding `Web Haptics API` into tentative deliverables.
-
-by Anssi Kostiainen, [w3c/charter-drafts PR #795](https://github.com/w3c/charter-drafts/pull/795)
-
-**Resolution** [Discussion has been postponed](https://github.com/w3c/charter-drafts/pull/795#issuecomment-4502569096), and 
-this change has not been integrated into the draft DAS charter. 
-And related issue `Venue and scope: Web Haptics API` has been filed at [w3c/charter-drafts #802](https://github.com/w3c/charter-drafts/issues/802).
-
-
+**Response:** The Web Haptics API [was **not** added to the draft charter](https://github.com/w3c/charter-drafts/pull/795#issuecomment-4502569096), pending further incubation and discussion on the appropriate venue(s) for this proposal. Also, the draft charter no longer contains any reference to haptics.

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -145,6 +145,10 @@ Christian Liebel confirmed [this point 4 has been resolved with set of PRs](http
 
 > We're concerned by the appearance of Web Serial in the [Tentative Deliverables](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html#tentative). At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead.
 
+In addition to concern raised at the TAG point 5, 
+[w3c/charter-drafts #783](https://github.com/w3c/charter-drafts/issues/783) has been opened by Marcos Cáceres 
+which has [marked as not a TAG consensus comment by Jeffrey Yasskin](https://github.com/w3c/charter-drafts/issues/783#issuecomment-4171422602).
+
 **Response** 
 The group has consensus to take up Mozilla's proposal to add Web Serial and other related specifications as a Tentative Deliverable in this Working Group. We also note that Mozilla has also started a parallel effort to create a WHATWG workstream for peripheral APIs. This may offer an alternative path for a forum that all implementers are comfortable joining.
 
@@ -254,27 +258,6 @@ by Haik Aftandilian, [w3c/charter-drafts #772](https://github.com/w3c/charter-dr
 
 by Haik Aftandilian, [w3c/charter-drafts #773](https://github.com/w3c/charter-drafts/issues/773)
 
-#### Concern raised to Web Serial in tentative Deliverables - Rejected
-
-> **Context:** This issue tracks a concern raised in the TAG review of the 2026 DAS WG charter (w3ctag/design-reviews#1187).
-> 
-> The TAG review states *(charter-affecting section, verbatim)*:
-> 
-> > "We're concerned by the appearance of Web Serial in the Tentative Deliverables. At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead."
-> 
-> Issue #771 proposes moving Web Serial from Tentative Deliverable to full Deliverable based on Mozilla's intent to prototype. However, the TAG's concern is specifically about **venue** — which WG is the right home for this work — not solely about the number of implementations. Moving it to a full DAS deliverable without resolving the venue question does not address the TAG's concern; it reinforces it.
-> 
-> Before this charter proceeds to AC review, the charter should either:
-> 1. Document that the venue question has been discussed with the Web Applications WG and record the outcome, or
-> 2. Explicitly state that Web Serial will not advance to full Deliverable in DAS until the venue question is resolved, and commit to a process and timeline for making that decision.
-> 
-> Related: #770, #771, w3ctag/design-reviews#1187
-
-by Marcos Cáceres, [w3c/charter-drafts #783](https://github.com/w3c/charter-drafts/issues/783)
-
-**Response** Five specifications of Peripheral APIs has been kept within the draft charter, to allow AC to weigh in. 
-We note this disagreement on this resolution. 
-
 #### Implementation across platform families - Noted
 
 > Posting as W3C Member (not TAG Member).
@@ -368,7 +351,7 @@ We note this disagreement on this resolution.
 
 > **Context:** This issue tracks concerns from both the W3C Council report and the TAG review of the 2026 DAS WG charter.
 > 
-? **W3C Council recommendation** (https://www.w3.org/2025/08/vibration2-council-report.html#recommendations, verbatim):
+> **W3C Council recommendation** (https://www.w3.org/2025/08/vibration2-council-report.html#recommendations, verbatim):
 > 
 > > "We recommend that the WG document what implementation experience the API currently has (issue 33). In the next rechartering process for the DAS WG, we anticipate that some W3C members will object to keeping a deliverable without a concrete plan and timeline for shipping in multiple major browser engines. We... recommend that the WG document the plan it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable."
 > 
@@ -406,7 +389,9 @@ by Léonie Watson, [w3c/charter-drafts #811](https://github.com/w3c/charter-draf
 
 **Response** Error fixed by [w3c/charter-drafts PR #813](https://github.com/w3c/charter-drafts/pull/813)
 
-#### Mentioning Haptics in DAS charter - Accepted
+#### Mentioning Haptics in DAS charter
+
+##### Remove `Haptics` from description of Vibration API - Accepted
 
 > **Note:** This concern is raised by @marcoscaceres in his personal capacity as a W3C member, not on behalf of the TAG. The TAG review (w3ctag/design-reviews#1187) was published before PR #770 introduced this specific language.
 > 
@@ -438,7 +423,7 @@ by Marcos Cáceres, [issue raised as w3c/charter-drafts #782](https://github.com
 
 **Response** The draft DAS charter has been updated by [w3c/charter-drafts #807](https://github.com/w3c/charter-drafts/pull/807). 
 
-#### Clarify haptics scope - Rejected
+##### Clarify haptics scope - Rejected
 
 Adding `semantic haptic feedback` into Scope, and `Gamepad haptics are out of scope for this WG` into Out of Scope
 
@@ -446,7 +431,7 @@ by Anssi Kostiainen, [w3c/charter-drafts PR #816](https://github.com/w3c/charter
 
 **Resolution** This change has not been integrated into the draft DAS charter.
 
-#### Adding Web Haptics API, Revise DAS WG charter with a new deliverable proposed by Microsoft - Deferred
+##### Adding Web Haptics API, Revise DAS WG charter with a new deliverable proposed by Microsoft - Deferred
 
 Adding `Web Haptics API` into tentative deliverables.
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -202,64 +202,6 @@ to come up in future design reviews for the individual specifications:
 
 **Response** The DAS WG noted these comments and continue onversation during further design review over each specification.
 
-## Other Strategy Issue Feedback
-
-### Vibration API single implementation issue - Deferred, Action taken within another Accepted comment
-
-> From the Vibration Council's [recommendations](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations): 
-> 
-> > We recommend that the WG document what [implementation experience](https://www.w3.org/policies/process/#implementation-experience) the [Vibration] API currently has ([issue 33](https://github.com/w3c/vibration/issues/33)). In the next rechartering process for the DAS WG, **we anticipate that some W3C members will object to keeping a deliverable without a concrete plan and timeline for shipping in multiple major browser engines.** ... we recommend that the WG document the plan it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable.
-> 
-> I don't believe this has been done yet. If the working group wants to avoid Formal Objections to the Charter, addressing the above would be a good start. Similarly, DAS should expect Formal Objections if the TAG's feedback also goes unaddressed. 
-> 
-> If you'd like to discuss how to address the above and avoid Formal Objections, happy to chat. 
-
-by Marcos Cáceres, [comment at w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-3917515554)
-
-**Response** Action has not taken directly to this comment, but implementation report has been published in other PR and also deffered to TAG concern point 3
-
-### Vibration API implementation report - Accepted
-
-> @plehegar @tidoust @himorin — a further development to flag.
-> 
-> [w3c/vibration#55](https://github.com/w3c/vibration/pull/55) is the implementation report the W3C Council recommended in its [August 2025 report](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations):
-> 
-> "We recommend that the WG document what implementation experience the API currently has (issue 33)."
-> 
-> That PR was closed today by @anssiko without merging and without WG discussion, citing (1) EFL WebKit as additional implementation experience, and (2) the PR being "misplaced". Both are rebutted in [a comment on the closed PR](https://github.com/w3c/vibration/pull/55#issuecomment-4205989183): the ewebkit/webkit fork is a discontinued snapshot last updated July 2017 covering end-of-life hardware; w3c/test-results/vibration contains raw Chrome/Firefox data from 2014, not an implementation report.
-> 
-> As PR author I have pull-only access to w3c/vibration and cannot reopen the PR myself. The closure leaves [vibration#33](https://github.com/w3c/vibration/issues/33) open and the Council's condition unmet — which is tracked as a gate condition for this charter in [charter-drafts#781](https://github.com/w3c/charter-drafts/issues/781).
-> 
-> This follows the earlier pattern of [11 SotD PRs being closed without discussion](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174). Can W3C staff weigh in on whether closing a PR that directly fulfils a Council recommendation, without WG discussion, is consistent with the process?
-
-by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777)
-
-and
-
-> Following up on the vibration#55 closure flagged in my [previous comment](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777).
-> 
-> @anssiko's most recent response directs me to regenerate the report using the [w3c/test-results toolchain](https://github.com/w3c/test-results) and submit it there instead. I've responded in [the PR](https://github.com/w3c/vibration/pull/55#issuecomment-4210563389) explaining why that wouldn't meet the Council's requirement: the generated format produces pass/fail percentages, but [W3C Process §6.3.2](https://www.w3.org/policies/process/#implementation-experience) requires a document that addresses whether implementations are independent, publicly deployed, created by non-authors, and whether difficulties have been reported. A score on a given date answers none of those questions.
-> 
-> I've also filed [w3c/test-results#232](https://github.com/w3c/test-results/issues/232) proposing that the toolchain either be updated to include §6.3.2 narrative sections, or that its README be clarified to distinguish conformance testing from REC advancement implementation reports.
-> 
-> The substantive question for the Team remains: the PR fulfils a Council recommendation verbatim ("document what implementation experience the API currently has"), and it has been closed without WG discussion. Can the W3C Team advise on the path forward?
-
-by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4210649633)
-
-**Response** Vibration API Implementation Report has been implemented by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55) merged.
-
-### Web Bluetooth, Web Serial, WebUSB as tentative deliverables - Won't fix
-
-> Posting as W3C Member (not TAG Member).
-> 
-> Update: [PR #786](https://github.com/w3c/charter-drafts/pull/786) (adding Web Bluetooth, Web Serial, and WebUSB as tentative deliverables) was merged on May 5. The wide review concerns listed above ([#798](https://github.com/w3c/charter-drafts/issues/798), [#799](https://github.com/w3c/charter-drafts/issues/799), [#771](https://github.com/w3c/charter-drafts/issues/771), [#772](https://github.com/w3c/charter-drafts/issues/772), [#773](https://github.com/w3c/charter-drafts/issues/773)) and the TAG's open review ([design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187)) remain unaddressed.
-> 
-> @plehegar @tidoust @himorin — can the Team clarify how these concerns will be addressed during the refinement phase?
-
-by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4380513758)
-
-**Response** The Team decided to include all five peripheral APIs specifications to tentative deliverables.
-
 ## Feedback provided to w3c/charter-drafts
 
 ### Peripheral APIs

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -100,7 +100,15 @@ by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
 
 > The [Vibration Council recommended](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations) that "the WG document the plan [to ship in multiple major browser engines] it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable." We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection.
 
-**Response** The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
+Similar comments have been added to w3c/strategy #530, such as 
+[comment](https://github.com/w3c/strategy/issues/530#issuecomment-3917515554), 
+[comment](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777),
+and [comment](https://github.com/w3c/strategy/issues/530#issuecomment-4210649633) by Marcos Cáceres. 
+
+**Response** The DAS WG resolved to add new implementation report for recently started Recommendation track specification 
+from Candidate Resommendation Snapshot by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55). 
+
+The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
 to add text not limited to the Vibration specification, but even further in relateion to TAG point 1, 
 the WG did not reached a concensus to accept or reject the PR.
 
@@ -124,6 +132,14 @@ by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819).
 > 
 > At the same time, we recognize that this is the only status the Process defines for patent protection of these kinds of specifications. At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that _developers reading a specification can tell at a glance which kind of document they're reading_.
 
+In addition to concern raised in TAG comment, several comments to w3ctag/design0reviews and w3c/strategy 
+has been made along with PRs to the DAS WG repositories by Marcos Cáceres 
+([first](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4159936835), 
+and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4163174410)) at w3ctag/design-reviews #1187, 
+and the same text posted as 
+[first](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174) and [second](https://github.com/w3c/strategy/issues/530#issuecomment-4163144358)
+at w3c/strategy #530), and PRs have been closed without merging. 
+
 **Response** Accepted through 10 PRs.
 
 The TAG opened 10 PRs to specifications, and all merged by the WG, 
@@ -145,8 +161,10 @@ Christian Liebel confirmed [this point 4 has been resolved with set of PRs](http
 
 > We're concerned by the appearance of Web Serial in the [Tentative Deliverables](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html#tentative). At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead.
 
-In addition to concern raised at the TAG point 5, 
-[w3c/charter-drafts #783](https://github.com/w3c/charter-drafts/issues/783) has been opened by Marcos Cáceres 
+In addition to this concern, 
+[additional comment]((https://github.com/w3c/strategy/issues/530#issuecomment-4380513758)) made by Marcos Cáceres to expand 
+concern over other newly added tentative deliverables, and 
+issue [w3c/charter-drafts #783](https://github.com/w3c/charter-drafts/issues/783) has been opened by Marcos Cáceres 
 which has [marked as not a TAG consensus comment by Jeffrey Yasskin](https://github.com/w3c/charter-drafts/issues/783#issuecomment-4171422602).
 
 **Response** 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -12,6 +12,12 @@ Comments were received through:
 ## Executive summary
 
 
+* 9 were Accepted, and resulted in charter changes.
+* 5 were Noted, without requiring charter change.
+* 4 were Deferred, to allow the AC to weigh in, or to later discussion for entire W3C strategy and investigation during specification development.
+* 4 were Rejected without change mage.
+* 2 were Won't fix
+* 3 XXX
 
 ## Horizontal reviews
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -272,7 +272,7 @@ by Marcos Cáceres, [w3c/charter-drafts #783](https://github.com/w3c/charter-dra
 **Response** Five specifications of Peripheral APIs has been kept within the draft charter, to allow AC to weigh in. 
 We note this disagreement on this resolution. 
 
-#### Implementation across platform families - Deferred 
+#### Implementation across platform families - Noted
 
 > Posting as W3C Member (not TAG Member).
 > 
@@ -302,8 +302,11 @@ We note this disagreement on this resolution.
 
 by Marcos Cáceres, [w3c/charter-drafts #799](https://github.com/w3c/charter-drafts/issues/799)
 
-**Response** The DAS WG describes current implementation situation for sensor APIs, and demonstrated possibility of 
+**Response**
+The DAS WG describes current implementation situation for sensor APIs, and demonstrated possibility of 
 implementation accross multiple platforms like over CPUs and SoCs.
+
+The draft DAS WG charter has been update to consider of single implementation status following change proposed by the TAG.
 
 #### Potential security risk on sandbox escape via device APIs - Noted
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -139,6 +139,9 @@ and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4
 and the same text posted as 
 [first](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174) and [second](https://github.com/w3c/strategy/issues/530#issuecomment-4163144358)
 at w3c/strategy #530), and PRs have been closed without merging. 
+In parallel, issue [w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780) has been raised by Marcos Cáceres to track this concern, 
+and the draft DAS WG charter has been edited to include inplementation status and 
+expected progress by [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770).
 
 **Response** Accepted through 10 PRs.
 
@@ -208,7 +211,7 @@ by Marcos Cáceres, [w3c/charte-drafts PR #784](https://github.com/w3c/charter-d
 `Here are my current thoughts on the proposal in this PR. This is not TAG consensus—it's just me so far. 
 We'll be discussing this in a TAG breakout later today, and hopefully we can report some more-unanimous position after that.`, 
 and this change has been closed without integrating per other changes proposed by the TAG in consensus 
-([w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), [w3c/charter-drafts PR #80](https://github.com/w3c/charter-drafts/pull/808)
+([w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808)
 and [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809)).
 
 #### Flagging design review concerens - Noted
@@ -240,7 +243,9 @@ by PRs [w3c/charter-drafts PR #786](https://github.com/w3c/charter-drafts/pull/7
 [w3c/charter-drafts #820](https://github.com/w3c/charter-drafts/pull/820). 
 We note disagreement from Apple on this resolution. 
 
-These deliverables are not listed as joint deliverables with the Web Applications WG.
+These deliverables are not listed as joint deliverables with the Web Applications WG, 
+by change made at [w3c/charter-drafts PR #812](https://github.com/w3c/charter-drafts/pull/812) following 
+issue [w3c/charter-drafts #810](https://github.com/w3c/charter-drafts/issues/810) by Léonie Watson.
 
 ##### Web Serial API
 
@@ -395,6 +400,8 @@ by Marcos Cáceres, [issue raised as w3c/charter-drafts #781](https://github.com
 
 **Response** Part of concern resolved by implementation report has been added by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55).
 
+No conclusion has been made in consensus for specification update plan of Vibration specification. 
+
 ### Other comments
 
 #### Wrong listing of geolocation specification - Accepted
@@ -457,6 +464,6 @@ by Anssi Kostiainen, [w3c/charter-drafts PR #795](https://github.com/w3c/charter
 
 **Resolution** [Discussion has been postponed](https://github.com/w3c/charter-drafts/pull/795#issuecomment-4502569096), and 
 this change has not been integrated into the draft DAS charter. 
-And related issue `Venue and scope: Web Haptics API` has been filed at [w3c/charter-drafts 802#](https://github.com/w3c/charter-drafts/issues/802).
+And related issue `Venue and scope: Web Haptics API` has been filed at [w3c/charter-drafts #802](https://github.com/w3c/charter-drafts/issues/802).
 
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -128,6 +128,42 @@ no conclusion has made.
 
 ### Other feedbacks on TAG review
 
+#### Address TAG review and Council recommendation feedback - Rejected
+
+> This PR applies the charter text suggestions posted in #770 (comment), addressing outstanding TAG review and W3C Council concerns. It is intended to be merged into PR #770 or land alongside it.
+> 
+> ## Changes
+> 
+> **Success Criteria — SotD signaling commitment** (addresses TAG charter concern, w3ctag/design-reviews#1187):
+> Adds three paragraphs committing the WG to: signal implementation status and trajectory in each spec's SotD; clearly label the role of single-engine specs; and review limited-support specs at least annually with publicly documented outcomes. Closes #780.
+> 
+> **Vibration — Expected progress** (addresses TAG charter concern + Council recommendation):
+> Replaces the vague "device haptics capabilities" text with a concrete commitment to publish the Council-recommended plan before AC review, with a visible `<i class="todo">` placeholder URL that must be filled in before the charter proceeds to AC review. Also requires the updated implementation report (w3c/vibration#33) to be publicly available before AC review opens. Coordinates haptics work with the Web Applications WG. Addresses #781, #782.
+> 
+> **Generic Sensor — Expected progress**:
+> Removes "infrastructure for future sensor APIs" framing. Adds commitment not to charter new Generic Sensor-derived deliverables without first documenting the architectural rationale relative to single-layer API alternatives. HTML comment in source notes the grounding and TAG context.
+> 
+> **Ambient Light Sensor + Proximity Sensor — Expected progress**:
+> Replaces vague "collect feedback and may publish a WD" with: proactively seek published implementer positions from non-participating engines, publish a summary of responses (including non-responses), and document a trajectory decision publicly.
+> 
+> ## Tracking issues
+> 
+> - #780 — SotD signaling commitment
+> - #781 — Vibration Council plan before AC review
+> - #782 — Vibration haptics scope conflict with WebApps WG
+> - #783 — Web Serial venue (not addressed in this PR — tracked separately)
+> 
+> cc @reillyeon @jyasskin @anssiko @himorin
+
+by Marcos Cáceres, [w3c/charte-drafts #784](https://github.com/w3c/charter-drafts/pull/784)
+
+**Resolution** Jeffrey Yasskin noted on this change that 
+`Here are my current thoughts on the proposal in this PR. This is not TAG consensus—it's just me so far. 
+We'll be discussing this in a TAG breakout later today, and hopefully we can report some more-unanimous position after that.`, 
+and this change has been closed without integrating per other changes proposed by the TAG in consensus 
+([w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), [w3c/charter-drafts PR #80](https://github.com/w3c/charter-drafts/pull/808)
+and [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809)).
+
 #### Flagging design review concerens - Noted
 
 In parallel to 5 points of concerns, the TAG made a comment in the same post as:

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -1,0 +1,265 @@
+# Disposition of Comments for the Devices and Sensors Working Group Charter
+
+This document is the disposition of comments received during the review
+of the [Devices and Sensor Working Group draft charter](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html).
+
+Comments were received through:
+
+- [w3c/strategy #530](https://github.com/w3c/strategy/issues/530) — Strategy funnel issue (horizontal reviews)
+- [w3ctag/design-reviews #1187](https://github.com/w3ctag/design-reviews/issues/1187) — TAG review
+- [Issues](https://github.com/w3c/charter-drafts/issues?q=is%3Aissue+[wg%2Fdas]) and [PRs](https://github.com/w3c/charter-drafts/pulls?q=is%3Apr+%5Bwg%2Fdas%5D) to [w3c/charter-drafts](https://github.com/w3c/charter-drafts/) repository
+
+## Executive summary
+
+
+
+## Horizontal reviews
+
+### Acceccibility - Noted
+
+> no comment or request from APA.
+
+by Ruoxi Ran, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-3848060439)
+
+### Security - Noted
+
+> hi, we have one comment from security, as the charter is focused on privacy and security, have you already a list of the main threats, and have you evaluated to put them in the charter itself?
+
+by Simone Onofri, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-3848628218)
+
+### Privacy - Noted
+
+> No concerns when discussed among chairs
+
+by pes10k, [w3cping/privacy-request #192 comment](https://github.com/w3cping/privacy-request/issues/192#issuecomment-3986193782)
+
+### Internationalization - Accepted
+
+> [from i18n WG](https://lists.w3.org/Archives/Team/w3t-archive/2026Feb/0016.html)
+> 
+> [Contact Picker API](https://www.w3.org/TR/contact-picker/) potentially has scary I18N monsters in it (e.g. https://github.com/w3c/contact-picker/issues/63 as i18n-needs-resolution) because it will necessarily deal with personal names and might include sorting (including using pronunciation data e.g. yomi) and searching, transliteration, and the like. If physical address fields are included, that draws in that further level of complexity. 
+> For the charter, if i18n WG can ask for early engagement/review and cite the additional need for coordination for the spec somewhere in section 5 that would probably be wise.
+> Since the Contact Picker API specification is a joint deliverable between the DAS WG and the [WebApps WG](https://www.w3.org/groups/wg/webapps), so this comment should be applicable also to the WebApps WG charter.
+
+by Atsushi Shimono, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-4153917428)
+
+**Response** Internationalization WG has been added to the Coordination section by [w3c/charter-drafts PR #804](https://github.com/w3c/charter-drafts/pull/804)
+
+## TAG review 
+
+### 5 points of concerns
+
+TAG raised 5 points of concerns ([w3ctag/design-reviews #1187 comment](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)), 
+and provided PRs for 4 points.
+
+#### Specifications with one implementation - XXX (not Accepted, not Won't fix, ???)
+
+> We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec is in Baseline. It makes sense to maintain non-consensus specifications while websites switch over to equivalent consensus APIs, but the charter should commit to only adding new features to the consensus versions. If there's not enough consensus on the new features to incorporate them into the core [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec, this WG could develop an extension specification that allows websites to mostly use the Baseline feature, with a few engine-specific extensions.
+
+The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
+the WG discussed on additional change over the PR but did not reach WG consensus. 
+
+**Response** The Team decided to override this concern by [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818), 
+with adding `including for security and privacy enhancements` over a PR by the TAG 
+to enable modification of adding new feature specifically related to security and privacy enhancements. 
+
+#### Involvement of multiple implementers - XXX (not Accepted, not Won't fix, ???)
+
+> We want to ensure that the other specifications fill clear user needs and are making appropriate tradeoffs between those user needs and any potential abuse of the APIs. In many WGs, we can rely on all 3 browser engines to check this, but since this WG does not currently include participation from all major browser engines, we're more concerned here. Could you add this goal to the charter for each of the specifications in that class? We see, for example, https://github.com/w3c/vibration/issues/45 to do this for Vibration, but it would be good to use the charter to ensure it gets done.
+
+The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
+the WG discussed on additional change over the PR, but did not resolved. 
+
+**Response** The Team decided to override this concern by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821), 
+with including a change suggested by Anssi to remove specifically mention to WebApps and 
+adding links to the Process for making maturity level used in text clear.
+
+#### Vibration API council concern - XXX
+
+> The [Vibration Council recommended](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations) that "the WG document the plan [to ship in multiple major browser engines] it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable." We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection.
+
+The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
+to add text not limited to the Vibration specification, but even further in relateion to TAG point 1, 
+the WG did not reached a concensus to accept or reject the PR.
+
+**Response** The Team decided to override this concern by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819), 
+with adding bringing specifications into CG as incubation along with publication as Discontinued Draft, 
+for making path clearer to continue incubation but not as completed end state.
+
+#### Support level in status section of specification - Accepted
+
+> We would like the WG to find a way to signal the expected support level for each specification. There's some discomfort on the TAG with using the same spec status?Candidate Recommendation?for all of:
+> * deprecated specs that are being maintained while websites migrate to a consensus replacement;
+> * features that are stable in one engine but opposed by the others;
+> * "living" consensus specs that never intend to advance to Recommendation; and
+> * consensus specs that are intended to advance to Recommendation.
+> 
+> At the same time, we recognize that this is the only status the Process defines for patent protection of these kinds of specifications. At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that _developers reading a specification can tell at a glance which kind of document they're reading_.
+
+**Response** Accepted through 10 PRs.
+
+The TAG opened 10 PRs to specifications, and all merged by the WG, 
+Christian Liebel confirmed [this point 4 has been resolved with set of PRs](https://github.com/w3c/strategy/issues/530#issuecomment-4549836034).
+
+* https://github.com/w3c/sensors/pull/494
+* https://github.com/w3c/magnetometer/pull/78
+* https://github.com/w3c/device-posture/pull/173
+* https://github.com/w3c/proximity/pull/63
+* https://github.com/w3c/compute-pressure/pull/319
+* https://github.com/w3c/accelerometer/pull/85
+* https://github.com/w3c/vibration/pull/65
+* https://github.com/w3c/gyroscope/pull/66
+* https://github.com/w3c/orientation-sensor/pull/87
+* https://github.com/w3c/ambient-light/pull/93
+
+
+#### Web Serial in tentative deliverables - Deferred
+
+> We're concerned by the appearance of Web Serial in the [Tentative Deliverables](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html#tentative). At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead.
+
+**Response** Conversation held in [email thread](https://lists.w3.org/Archives/Public/www-archive/2026May/0000.html), 
+no conclusion has made. 
+
+### Other feedbacks on TAG review
+
+#### Flagging design review concerens - Noted
+
+In parallel to 5 points of concerns, the TAG made a comment in the same post as:
+
+> The following concerns don't affect the charter, but we want to flag a few issues that are likely 
+to come up in future design reviews for the individual specifications:
+> 
+> * We will always look more critically at specifications developed by WGs without members from all major browser engines, since we want there to be [One Web](https://www.w3.org/TR/ethical-web-principles/#multi) in the long run, and the fact that some browsers decide not to implement, inherently means there are concerns with the design. The WG should be prepared to explain how the non-members' critical feedback has been sought and considered.
+> * The Generic Sensor architecture seems overcomplicated overall. In reviews of features that use it, we'd appreciate some justification for why that architecture is better than defining APIs in a single layer, as [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) does.
+> * Are the signals in the Battery API still the right ones to help websites help users achieve their goals? Would a "please reduce power use" signal be sufficient, with the UA in charge of deciding how the precise battery level and charging state contribute to that signal?
+
+**Response** The DAS WG noted these comments and continue onversation during further design review over each specification.
+
+#### Support level in status of specifications - Rejected
+
+> Status update: to implement the TAG's request that "each document's support level should be in its SotD section," I opened 11 PRs adding `.advisement` boxes to the SotD of each DAS WG spec. They have since been closed without discussion:
+> 
+> - [w3c/sensors#492](https://github.com/w3c/sensors/pull/492) — Generic Sensor API
+> - [w3c/accelerometer#84](https://github.com/w3c/accelerometer/pull/84)
+> - [w3c/gyroscope#65](https://github.com/w3c/gyroscope/pull/65)
+> - [w3c/magnetometer#77](https://github.com/w3c/magnetometer/pull/77)
+> - [w3c/ambient-light#92](https://github.com/w3c/ambient-light/pull/92)
+> - [w3c/orientation-sensor#86](https://github.com/w3c/orientation-sensor/pull/86)
+> - [w3c/proximity#62](https://github.com/w3c/proximity/pull/62)
+> - [w3c/compute-pressure#318](https://github.com/w3c/compute-pressure/pull/318)
+> - [w3c/battery#70](https://github.com/w3c/battery/pull/70)
+> - [w3c/device-posture#172](https://github.com/w3c/device-posture/pull/172)
+> - [w3c/vibration#57](https://github.com/w3c/vibration/pull/57)
+> 
+> For charter-level text, [charter-drafts#770](https://github.com/w3c/charter-drafts/pull/770) is in progress. [charter-drafts#784](https://github.com/w3c/charter-drafts/pull/784) proposes specific text addressing the TAG's concerns on SotD signalling, Vibration, and Generic Sensor framing, intended to land alongside #770. The remaining concerns are tracked in [#780](https://github.com/w3c/charter-drafts/issues/780), [#781](https://github.com/w3c/charter-drafts/issues/781), [#782](https://github.com/w3c/charter-drafts/issues/782), and [#783](https://github.com/w3c/charter-drafts/issues/783).
+> 
+> The TAG's concern that each document's support level should be in its SotD section remains open at the spec level, pending WG discussion.
+
+by Marcos Cáceres, in two comments ([first](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4159936835), 
+and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4163174410)) at w3ctag/design-reviews #1187.
+Also the same text has been posted by the same person to w3c/strategy #530 at 
+[first](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174) and [second](https://github.com/w3c/strategy/issues/530#issuecomment-4163144358).
+
+**Response** the DAS WG closed opened PRs without merging for ongoing discussion during continuing charter refinement phase
+
+## Other Strategy Issue Feedback
+
+### Vibration API single implementation issue - Deferred, Action taken within another Accepted comment
+
+> From the Vibration Council's [recommendations](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations): 
+> 
+> > We recommend that the WG document what [implementation experience](https://www.w3.org/policies/process/#implementation-experience) the [Vibration] API currently has ([issue 33](https://github.com/w3c/vibration/issues/33)). In the next rechartering process for the DAS WG, **we anticipate that some W3C members will object to keeping a deliverable without a concrete plan and timeline for shipping in multiple major browser engines.** ... we recommend that the WG document the plan it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable.
+> 
+> I don't believe this has been done yet. If the working group wants to avoid Formal Objections to the Charter, addressing the above would be a good start. Similarly, DAS should expect Formal Objections if the TAG's feedback also goes unaddressed. 
+> 
+> If you'd like to discuss how to address the above and avoid Formal Objections, happy to chat. 
+
+by Marcos Cáceres, [comment at w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-3917515554)
+
+**Response** Action has not taken directly to this comment, but implementation report has been published in other PR and also deffered to TAG concern point 3
+
+### Vibration API implementation report - Accepted
+
+> @plehegar @tidoust @himorin — a further development to flag.
+> 
+> [w3c/vibration#55](https://github.com/w3c/vibration/pull/55) is the implementation report the W3C Council recommended in its [August 2025 report](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations):
+> 
+> "We recommend that the WG document what implementation experience the API currently has (issue 33)."
+> 
+> That PR was closed today by @anssiko without merging and without WG discussion, citing (1) EFL WebKit as additional implementation experience, and (2) the PR being "misplaced". Both are rebutted in [a comment on the closed PR](https://github.com/w3c/vibration/pull/55#issuecomment-4205989183): the ewebkit/webkit fork is a discontinued snapshot last updated July 2017 covering end-of-life hardware; w3c/test-results/vibration contains raw Chrome/Firefox data from 2014, not an implementation report.
+> 
+> As PR author I have pull-only access to w3c/vibration and cannot reopen the PR myself. The closure leaves [vibration#33](https://github.com/w3c/vibration/issues/33) open and the Council's condition unmet — which is tracked as a gate condition for this charter in [charter-drafts#781](https://github.com/w3c/charter-drafts/issues/781).
+> 
+> This follows the earlier pattern of [11 SotD PRs being closed without discussion](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174). Can W3C staff weigh in on whether closing a PR that directly fulfils a Council recommendation, without WG discussion, is consistent with the process?
+
+by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777)
+
+and
+
+> Following up on the vibration#55 closure flagged in my [previous comment](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777).
+> 
+> @anssiko's most recent response directs me to regenerate the report using the [w3c/test-results toolchain](https://github.com/w3c/test-results) and submit it there instead. I've responded in [the PR](https://github.com/w3c/vibration/pull/55#issuecomment-4210563389) explaining why that wouldn't meet the Council's requirement: the generated format produces pass/fail percentages, but [W3C Process §6.3.2](https://www.w3.org/policies/process/#implementation-experience) requires a document that addresses whether implementations are independent, publicly deployed, created by non-authors, and whether difficulties have been reported. A score on a given date answers none of those questions.
+> 
+> I've also filed [w3c/test-results#232](https://github.com/w3c/test-results/issues/232) proposing that the toolchain either be updated to include §6.3.2 narrative sections, or that its README be clarified to distinguish conformance testing from REC advancement implementation reports.
+> 
+> The substantive question for the Team remains: the PR fulfils a Council recommendation verbatim ("document what implementation experience the API currently has"), and it has been closed without WG discussion. Can the W3C Team advise on the path forward?
+
+by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4210649633)
+
+**Response** Vibration API Implementation Report has been implemented by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55) merged.
+
+### Web Bluetooth, Web Serial, WebUSB as tentative deliverables - Won't fix
+
+> Posting as W3C Member (not TAG Member).
+> 
+> Update: [PR #786](https://github.com/w3c/charter-drafts/pull/786) (adding Web Bluetooth, Web Serial, and WebUSB as tentative deliverables) was merged on May 5. The wide review concerns listed above ([#798](https://github.com/w3c/charter-drafts/issues/798), [#799](https://github.com/w3c/charter-drafts/issues/799), [#771](https://github.com/w3c/charter-drafts/issues/771), [#772](https://github.com/w3c/charter-drafts/issues/772), [#773](https://github.com/w3c/charter-drafts/issues/773)) and the TAG's open review ([design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187)) remain unaddressed.
+> 
+> @plehegar @tidoust @himorin — can the Team clarify how these concerns will be addressed during the refinement phase?
+
+by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4380513758)
+
+**Response** The Team decided to include all five peripheral APIs specifications to tentative deliverables.
+
+### Unresolved comment by the commenter - Rejected
+
+> @plehegar — thank you for the update.
+> 
+> Can you help me understand how this aligns with three things?
+> 
+> **1. Your own gate condition (2026-02-24):**
+> 
+> "I don't think that publishing additional explainers, use cases or demos address the comment. [...] Without such response, I don't think the charter should be sent to the AC for review."
+> 
+> The point-by-point response you required has not been provided. None of the issues listed above have received a formal response from the WG.
+> 
+> **2. [W3C Process §4.2](https://www.w3.org/policies/process/#charter-review):**
+> 
+> "All issues filed against the charter draft must be formally addressed, and their resolutions tracked in a disposition of comments highlighting any issues not resolved by consensus."
+> 
+> There is currently no disposition of comments, as far as I know. Issues [#798](https://github.com/w3c/charter-drafts/issues/798), [#799](https://github.com/w3c/charter-drafts/issues/799), [#780](https://github.com/w3c/charter-drafts/issues/780), and [#782](https://github.com/w3c/charter-drafts/issues/782) have received zero responses. The TAG's review ([design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187)) remains open.
+> 
+> **3. Process §4.2 also requires:**
+> 
+> "When the Team initiates an Advisory Committee Review, they must include a disposition of comments received during the charter refinement process, highlighting any issues that were closed despite sustained objections."
+> 
+> The Team cannot initiate AC review without first producing this disposition. Given that multiple issues have received no WG response, what will that disposition say?
+> 
+> Can you clarify the intended path?
+
+by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4384373803)
+
+and 
+
+> For the record: the TAG does have consensus on these concerns.
+> 
+> [design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187) is a published collective review. Jeffrey re-opened it on April 8 confirming the concerns remain unresolved. At our April 7 meeting with DAS WG guests, Brian, Heather, and Jeffrey all voiced support for the signaling concern. The TAG appointed @christianliebel as deputy to work with the WG, documented in meeting minutes.
+> 
+> The decision to condition AC review on a response was the Team's (Feb 24): "Without such response, I don't think the charter should be sent to the AC for review." That was a Team decision, not a TAG request. The TAG asked for concerns to be addressed. That's our role per Process.
+> 
+> If the charter goes to AC with these concerns unresolved in the disposition, that's fine. But the disposition must accurately reflect that these are collective TAG concerns, not one individual's.
+> 
+> Also: [#798](https://github.com/w3c/charter-drafts/issues/798) and [#799](https://github.com/w3c/charter-drafts/issues/799) are W3C Member wide review concerns grounded in peer-reviewed security research, cross-engine implementation data, and WebKit's published [community positions](https://github.com/WebKit/standards-positions/issues/199). "One individual" is not an accurate characterization of concerns backed by a collective TAG review, a browser engine's community positions, and an academic paper from CISPA.
+
+by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4397542820)
+
+**Response** No action taken, just situation described against comments.

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -211,11 +211,14 @@ three specifications (out of five listed in whatwg/sg PR #264) has been proposed
 
 #### Proposals raised by Mozilla - Accepted
 
-**Resolution** The draft charter has been updated to include all three specifications proposed by issues to w3c/charter-drafts, 
+**Resolution**
+The draft charter has been updated to include all three specifications proposed by issues to w3c/charter-drafts, 
 and extended to 2 additional deliverables to allow the AC to weigh in, 
 by PRs [w3c/charter-drafts PR #786](https://github.com/w3c/charter-drafts/pull/786) and 
 [w3c/charter-drafts #820](https://github.com/w3c/charter-drafts/pull/820). 
 We note disagreement from Apple on this resolution. 
+
+These deliverables are not listed as joint deliverables with the Web Applications WG.
 
 ##### Web Serial API
 
@@ -359,50 +362,7 @@ by Marcos Cáceres, [w3c/charter-drafts #798](https://github.com/w3c/charter-dra
 We note this disagreement on this resolution. 
 
 
-#### Remove potential joint deliverables for three Peripheral APIs - Accepted
-
-> Update the notes that indicate Web Bluetooth, Web Serial, and Web USB may become joint deliverables with the WebApps WG, since WebApps is unable to accept any more specifications at this time.
-> 
-> @himorin , @anssiko, @reillyeon, @w3c/marcomm, @siusin  
-
-by Léonie Watson, [w3c/charter-drafts #810](https://github.com/w3c/charter-drafts/issues/810)
-
-**Response** The draft charter has been updated by [w3c/charter-drafts PR #812](https://github.com/w3c/charter-drafts/pull/812) to align with this comment. 
-
 ### Comments related to implementation status and language
-
-#### Revise DAS WG charter with clearer implementation status - Accepted
-
-> Each deliverable gets an "implementation status" and "expected progress" section to document the current state as of the time of chartering and the work the group will do to advance each deliverable.
-
-by Reilly Grant, [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770)
-
-**Resolution** Although this change does not satisfy concerns of the TAG, this change has been integrated into 
-the draft DAS charter for better explanation. 
-
-#### Support level of specification in each status section - Accepted
-
-> **Context:** This issue tracks a concern raised in the TAG review of the 2026 DAS WG charter (w3ctag/design-reviews#1187).
-> 
-> The TAG review states *(charter-affecting section, verbatim)*:
-> 
-> > "We would like the WG to find a way to signal the expected support level for each specification... At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that *developers reading a specification can tell at a glance which kind of document they're reading*."
-> 
-> PR #770 adds implementation status text to the charter itself, which is a welcome step. However, the charter currently makes no commitment to reflect that status in the specifications that developers actually read.
-> 
-> The charter should include language along the following lines *(proposed in [#770 (comment)](https://github.com/w3c/charter-drafts/pull/770#discussion_r2881370853))*:
-> 
-> > The Working Group will ensure that each specification clearly communicates both its implementation status and its intended trajectory along the W3C Recommendation Track. At a minimum, the Status of This Document section of each specification will describe the current level of implementation support and whether the specification is expected to advance toward widely implemented Recommendation status.
-> >
-> > For specifications with limited or single-engine deployment, the Working Group will ensure that the specification clearly signals its role and intended direction — for example, whether it is an experimental abstraction, a transitional design that points developers toward a consensus alternative, or work with limited deployment serving as documentation.
-> >
-> > The Working Group will review specifications with limited implementation support at least annually to evaluate their progress, relevance, and intended trajectory, and will document the outcome of those evaluations publicly.
-> 
-> Related: #770, w3ctag/design-reviews#1187
-
-by Marcos Cáceres, [issue raised as w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780)
-
-**Response** Referenced PR [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770) has been integrated into the draft charter.
 
 #### Implementation report and WG plan for Vibration API - Won't fix
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -56,35 +56,37 @@ and provided PRs for 4 points.
 
 > We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec is in Baseline. It makes sense to maintain non-consensus specifications while websites switch over to equivalent consensus APIs, but the charter should commit to only adding new features to the consensus versions. If there's not enough consensus on the new features to incorporate them into the core [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec, this WG could develop an extension specification that allows websites to mostly use the Baseline feature, with a few engine-specific extensions.
 
-The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
+**Response** The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
 the WG discussed on additional change over the PR but did not reach WG consensus. 
 
-**Response** The Team decided to override this concern by [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818), 
-with adding `including for security and privacy enhancements` over a PR by the TAG 
-to enable modification of adding new feature specifically related to security and privacy enhancements. 
+**Resolution** The draft charter has been updated following TAG proposal with adding amended text 
+as `including for security and privacy enhancements`
+to enable modification of adding new feature specifically related to security and privacy enhancements, 
+at [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818), 
 
 #### Involvement of multiple implementers - XXX (not Accepted, not Won't fix, ???)
 
 > We want to ensure that the other specifications fill clear user needs and are making appropriate tradeoffs between those user needs and any potential abuse of the APIs. In many WGs, we can rely on all 3 browser engines to check this, but since this WG does not currently include participation from all major browser engines, we're more concerned here. Could you add this goal to the charter for each of the specifications in that class? We see, for example, https://github.com/w3c/vibration/issues/45 to do this for Vibration, but it would be good to use the charter to ensure it gets done.
 
-The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
+**Response** The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
 the WG discussed on additional change over the PR, but did not resolved. 
 
-**Response** The Team decided to override this concern by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821), 
-with including a change suggested by Anssi to remove specifically mention to WebApps and 
-adding links to the Process for making maturity level used in text clear.
+**Resolution** The draft charter has been updated following TAG proposal with integrating a change suggested by Anssi 
+to remove specifically mention to WebApps, and with adding links to the Process for making maturity level used in text clear, 
+by [w3c/charter-drafts PR #821]
 
 #### Vibration API council concern - XXX
 
 > The [Vibration Council recommended](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations) that "the WG document the plan [to ship in multiple major browser engines] it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable." We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection.
 
-The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
+**Response** The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
 to add text not limited to the Vibration specification, but even further in relateion to TAG point 1, 
 the WG did not reached a concensus to accept or reject the PR.
 
-**Response** The Team decided to override this concern by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819), 
-with adding bringing specifications into CG as incubation along with publication as Discontinued Draft, 
-for making path clearer to continue incubation but not as completed end state.
+**Resolution** The draft charter has been updated following TAG porposal 
+with adding amended text to enable bringing specifications into CG as incubation along with publication as Discontinued Draft, 
+for making path clearer to continue incubation but not as completed end state, 
+by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
 
 #### Support level in status section of specification - Accepted
 
@@ -220,46 +222,110 @@ by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strate
 
 **Response** The Team decided to include all five peripheral APIs specifications to tentative deliverables.
 
-### Unresolved comment by the commenter - Rejected
+## Feedback provided to w3c/charter-drafts
 
-> @plehegar — thank you for the update.
-> 
-> Can you help me understand how this aligns with three things?
-> 
-> **1. Your own gate condition (2026-02-24):**
-> 
-> "I don't think that publishing additional explainers, use cases or demos address the comment. [...] Without such response, I don't think the charter should be sent to the AC for review."
-> 
-> The point-by-point response you required has not been provided. None of the issues listed above have received a formal response from the WG.
-> 
-> **2. [W3C Process §4.2](https://www.w3.org/policies/process/#charter-review):**
-> 
-> "All issues filed against the charter draft must be formally addressed, and their resolutions tracked in a disposition of comments highlighting any issues not resolved by consensus."
-> 
-> There is currently no disposition of comments, as far as I know. Issues [#798](https://github.com/w3c/charter-drafts/issues/798), [#799](https://github.com/w3c/charter-drafts/issues/799), [#780](https://github.com/w3c/charter-drafts/issues/780), and [#782](https://github.com/w3c/charter-drafts/issues/782) have received zero responses. The TAG's review ([design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187)) remains open.
-> 
-> **3. Process §4.2 also requires:**
-> 
-> "When the Team initiates an Advisory Committee Review, they must include a disposition of comments received during the charter refinement process, highlighting any issues that were closed despite sustained objections."
-> 
-> The Team cannot initiate AC review without first producing this disposition. Given that multiple issues have received no WG response, what will that disposition say?
-> 
-> Can you clarify the intended path?
+### Peripheral APIs
 
-by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4384373803)
+Before submission by Mozilla to [whatwg/sg PR #264](https://github.com/whatwg/sg/pull/264/), 
+three specifications (out of five listed in whatwg/sg PR #264) has been proposed to be included into tentative deliverables. 
 
-and 
+#### Proposals raised by Mozilla - Accepted
 
-> For the record: the TAG does have consensus on these concerns.
-> 
-> [design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187) is a published collective review. Jeffrey re-opened it on April 8 confirming the concerns remain unresolved. At our April 7 meeting with DAS WG guests, Brian, Heather, and Jeffrey all voiced support for the signaling concern. The TAG appointed @christianliebel as deputy to work with the WG, documented in meeting minutes.
-> 
-> The decision to condition AC review on a response was the Team's (Feb 24): "Without such response, I don't think the charter should be sent to the AC for review." That was a Team decision, not a TAG request. The TAG asked for concerns to be addressed. That's our role per Process.
-> 
-> If the charter goes to AC with these concerns unresolved in the disposition, that's fine. But the disposition must accurately reflect that these are collective TAG concerns, not one individual's.
-> 
-> Also: [#798](https://github.com/w3c/charter-drafts/issues/798) and [#799](https://github.com/w3c/charter-drafts/issues/799) are W3C Member wide review concerns grounded in peer-reviewed security research, cross-engine implementation data, and WebKit's published [community positions](https://github.com/WebKit/standards-positions/issues/199). "One individual" is not an accurate characterization of concerns backed by a collective TAG review, a browser engine's community positions, and an academic paper from CISPA.
+**Resolution** The draft charter has been updated to include all three specifications proposed by issues to w3c/charter-drafts, 
+and extended to 2 additional deliverables to allow the AC to weigh in, 
+by PRs [w3c/charter-drafts PR #786](https://github.com/w3c/charter-drafts/pull/786) and 
+[w3c/charter-drafts #820](https://github.com/w3c/charter-drafts/pull/820). 
+We note disagreement from Apple on this resolution. 
 
-by Marcos Cáceres, [comment to w3c/strategy #530](https://github.com/w3c/strategy/issues/530#issuecomment-4397542820)
+##### Web Serial API
 
-**Response** No action taken, just situation described against comments.
+> Can Web Serial be moved from “tentative deliverable” to “deliverable” given Mozilla has announced an intent to prototype which would make two implementations?
+> 
+> Here's Mozilla’s intent to prototype: https://groups.google.com/a/mozilla.org/g/dev-platform/c/EDLTASS4Zik/m/LXJRL6yFCQAJ
+> 
+> We prefer to keep the existing note in the listing of the deliverable: "Note: This work may turn into a joint deliverable with the Web Applications Working Group."
+
+by Haik Aftandilian, [w3c/charter-drafts #771](https://github.com/w3c/charter-drafts/issues/771)
+
+##### WebUSB
+
+> We (Mozilla Firefox) are considering the WebUSB API ([Firefox bug 2022432](https://bugzilla.mozilla.org/show_bug.cgi?id=2022432)) and thus request adding the WebUSB API in the DAS WG charter "Tentative Deliverables" as follows:
+> 
+> [WebUSB API](https://wicg.github.io/webusb/)
+> An API for reading and writing from a USB device through script.
+> Draft state: Draft Community Group Report
+> Adopted Draft: [Adopted from WICG](https://wicg.github.io/webusb/)
+> Note: This work may turn into a joint deliverable with the [Web Applications Working Group](https://www.w3.org/groups/wg/webapps).
+
+by Haik Aftandilian, [w3c/charter-drafts #772](https://github.com/w3c/charter-drafts/issues/772)
+
+##### Web Bluetooth
+
+> We (Mozilla Firefox) are considering the Web Bluetooth API ([Firefox bug 2022433](https://bugzilla.mozilla.org/show_bug.cgi?id=2022433)) and thus request adding the Web Bluetooth API in the DAS WG charter "Tentative Deliverables" as follows:
+> 
+> [Web Bluetooth API](https://webbluetoothcg.github.io/web-bluetooth/)
+> An API to discover and communicate with devices over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT).
+> Draft state: Draft Community Group Report
+> Adopted Draft: [Adopted from Web Bluetooth Community Group](https://webbluetoothcg.github.io/web-bluetooth/)
+> Note: This work may turn into a joint deliverable with the [Web Applications Working Group](https://www.w3.org/groups/wg/webapps).
+
+by Haik Aftandilian, [w3c/charter-drafts #773](https://github.com/w3c/charter-drafts/issues/773)
+
+#### Concern raised to Web Serial in tentative Deliverables - Rejected
+
+> **Context:** This issue tracks a concern raised in the TAG review of the 2026 DAS WG charter (w3ctag/design-reviews#1187).
+> 
+> The TAG review states *(charter-affecting section, verbatim)*:
+> 
+> > "We're concerned by the appearance of Web Serial in the Tentative Deliverables. At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead."
+> 
+> Issue #771 proposes moving Web Serial from Tentative Deliverable to full Deliverable based on Mozilla's intent to prototype. However, the TAG's concern is specifically about **venue** — which WG is the right home for this work — not solely about the number of implementations. Moving it to a full DAS deliverable without resolving the venue question does not address the TAG's concern; it reinforces it.
+> 
+> Before this charter proceeds to AC review, the charter should either:
+> 1. Document that the venue question has been discussed with the Web Applications WG and record the outcome, or
+> 2. Explicitly state that Web Serial will not advance to full Deliverable in DAS until the venue question is resolved, and commit to a process and timeline for making that decision.
+> 
+> Related: #770, #771, w3ctag/design-reviews#1187
+
+by Marcos Cáceres, [w3c/charter-drafts #783](https://github.com/w3c/charter-drafts/issues/783)
+
+**Response** Five specifications of Peripheral APIs has been kept within the draft charter, to allow AC to weigh in. 
+We note this disagreement on this resolution. 
+
+#### Remove potential joint deliverables for three Peripheral APIs - Accepted
+
+> Update the notes that indicate Web Bluetooth, Web Serial, and Web USB may become joint deliverables with the WebApps WG, since WebApps is unable to accept any more specifications at this time.
+> 
+> @himorin , @anssiko, @reillyeon, @w3c/marcomm, @siusin  
+
+by Léonie Watson, [w3c/charter-drafts #810](https://github.com/w3c/charter-drafts/issues/810)
+
+**Response** The draft charter has been updated by [w3c/charter-drafts PR #812](https://github.com/w3c/charter-drafts/pull/812) to align with this comment. 
+
+### Comments related to implementation status and language
+
+#### Support level of specification in each status section - Accepted
+
+> **Context:** This issue tracks a concern raised in the TAG review of the 2026 DAS WG charter (w3ctag/design-reviews#1187).
+> 
+> The TAG review states *(charter-affecting section, verbatim)*:
+> 
+> > "We would like the WG to find a way to signal the expected support level for each specification... At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that *developers reading a specification can tell at a glance which kind of document they're reading*."
+> 
+> PR #770 adds implementation status text to the charter itself, which is a welcome step. However, the charter currently makes no commitment to reflect that status in the specifications that developers actually read.
+> 
+> The charter should include language along the following lines *(proposed in [#770 (comment)](https://github.com/w3c/charter-drafts/pull/770#discussion_r2881370853))*:
+> 
+> > The Working Group will ensure that each specification clearly communicates both its implementation status and its intended trajectory along the W3C Recommendation Track. At a minimum, the Status of This Document section of each specification will describe the current level of implementation support and whether the specification is expected to advance toward widely implemented Recommendation status.
+> >
+> > For specifications with limited or single-engine deployment, the Working Group will ensure that the specification clearly signals its role and intended direction — for example, whether it is an experimental abstraction, a transitional design that points developers toward a consensus alternative, or work with limited deployment serving as documentation.
+> >
+> > The Working Group will review specifications with limited implementation support at least annually to evaluate their progress, relevance, and intended trajectory, and will document the outcome of those evaluations publicly.
+> 
+> Related: #770, w3ctag/design-reviews#1187
+
+by Marcos Cáceres, [issue raised as w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780)
+
+**Response** Referenced PR [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770) has been integrated into the draft charter.
+
+

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -21,7 +21,7 @@ Comments were received through:
 
 ## Horizontal reviews
 
-### Acceccibility - Noted
+### Accessibility - Noted
 
 > no comment or request from APA.
 
@@ -34,8 +34,9 @@ by Ruoxi Ran, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues
 by Simone Onofri, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-3848628218)
 
 **Response** The DAS WG appreciate the comment, and described situation in 
-[w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-4569236084), that these are 
-[captured in Generic Sensors specification](https://w3c.github.io/sensors/#security-and-privacy) for sensor API specifications.
+[w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-4569236084).
+
+> The group does not maintain a single list of main security and privacy threats. While there are some common themes among APIs (e.g. there are some threats common to sensor APIs that are captured in the [Generic Sensors specification](https://w3c.github.io/sensors/#security-and-privacy)) putting something together that covers all the specifications under the charter (e.g. [Contact Picker](https://www.w3.org/TR/contact-picker/#privacy), which has a very different set of considerations than sensor APIs) would risk creating overlap with W3C-level security and privacy guidance such as the [Threat Model for the Web](https://www.w3.org/TR/threat-model-web/) and the TAG's [Security and Privacy Questionnaire](https://www.w3.org/TR/security-privacy-questionnaire/). To the extend where it would be valuable to collect common security and privacy guidance in a single place, I think the Generic Sensors example is a good compromise between not duplicating high-level web platform design guidance and gathering domain-specific considerations.
 
 ### Privacy - Noted
 
@@ -62,7 +63,7 @@ by Atsushi Shimono, [w3c/strategy #530 comment](https://github.com/w3c/strategy/
 TAG raised 5 points of concerns ([w3ctag/design-reviews #1187 comment](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)), 
 and provided PRs for 4 points.
 
-#### Specifications with one implementation - XXX (not Accepted, not Won't fix, ???)
+#### Specifications with one implementation - Accepted with amendment made
 
 > We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec is in Baseline. It makes sense to maintain non-consensus specifications while websites switch over to equivalent consensus APIs, but the charter should commit to only adding new features to the consensus versions. If there's not enough consensus on the new features to incorporate them into the core [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec, this WG could develop an extension specification that allows websites to mostly use the Baseline feature, with a few engine-specific extensions.
 
@@ -74,7 +75,7 @@ as `including for security and privacy enhancements`
 to enable modification of adding new feature specifically related to security and privacy enhancements, 
 at [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818), 
 
-#### Involvement of multiple implementers - XXX (not Accepted, not Won't fix, ???)
+#### Involvement of multiple implementers - Accepted with amendment made
 
 > We want to ensure that the other specifications fill clear user needs and are making appropriate tradeoffs between those user needs and any potential abuse of the APIs. In many WGs, we can rely on all 3 browser engines to check this, but since this WG does not currently include participation from all major browser engines, we're more concerned here. Could you add this goal to the charter for each of the specifications in that class? We see, for example, https://github.com/w3c/vibration/issues/45 to do this for Vibration, but it would be good to use the charter to ensure it gets done.
 
@@ -85,7 +86,7 @@ the WG discussed on additional change over the PR, but did not resolved.
 to remove specifically mention to WebApps, and with adding links to the Process for making maturity level used in text clear, 
 by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
 
-#### Vibration API council concern - XXX
+#### Vibration API council concern - Accepted with amendment made
 
 > The [Vibration Council recommended](https://www.w3.org/2025/08/vibration2-council-report.html#recommendations) that "the WG document the plan [to ship in multiple major browser engines] it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable." We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection.
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -12,13 +12,13 @@ Comments were received through:
 ## Executive summary
 
 
-* 9 were Accepted, and resulted in charter changes.
-* 3 were Accepted with amended text
-* 5 were Noted, without requiring charter change.
-* 3 were Deferred, to later discussion for entire W3C strategy and investigation during specification development.
-* 1 was Declined, to allow the AC to weigh in
-* 3 were Rejected without change mage.
-* 2 were Won't fix
+* 5 were Accepted, and resulted in charter changes.
+* 3 were Accepted with amended text, and resulted in charter changes.
+* 6 were Noted, without requiring charter change.
+* 1 was Deferred, to later discussion for entire W3C strategy and investigation during specification development.
+* 1 was Declined, to allow the AC to weigh in.
+* 2 were Rejected without change mage.
+* 1 was Won't fix.
 
 ## Horizontal reviews
 
@@ -133,12 +133,13 @@ by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819).
 > At the same time, we recognize that this is the only status the Process defines for patent protection of these kinds of specifications. At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that _developers reading a specification can tell at a glance which kind of document they're reading_.
 
 In addition to concern raised in TAG comment, several comments to w3ctag/design0reviews and w3c/strategy 
-has been made along with PRs to the DAS WG repositories by Marcos Cáceres 
+has been made along with PRs to the DAS WG repositories by Marcos Cáceres, 
 ([first](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4159936835), 
-and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4163174410)) at w3ctag/design-reviews #1187, 
+and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4163174410) at w3ctag/design-reviews #1187, 
 and the same text posted as 
 [first](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174) and [second](https://github.com/w3c/strategy/issues/530#issuecomment-4163144358)
 at w3c/strategy #530), and PRs have been closed without merging. 
+
 In parallel, issue [w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780) has been raised by Marcos Cáceres to track this concern, 
 and the draft DAS WG charter has been edited to include inplementation status and 
 expected progress by [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770).

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -13,11 +13,12 @@ Comments were received through:
 
 
 * 9 were Accepted, and resulted in charter changes.
+* 3 were Accepted with amended text
 * 5 were Noted, without requiring charter change.
-* 4 were Deferred, to allow the AC to weigh in, or to later discussion for entire W3C strategy and investigation during specification development.
-* 4 were Rejected without change mage.
+* 3 were Deferred, to later discussion for entire W3C strategy and investigation during specification development.
+* 1 was Declined, to allow the AC to weigh in
+* 3 were Rejected without change mage.
 * 2 were Won't fix
-* 3 XXX
 
 ## Horizontal reviews
 
@@ -70,7 +71,11 @@ and provided PRs for 4 points.
 **Response** The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
 the WG discussed on additional change over the PR but did not reach WG consensus. 
 
-**Resolution** The draft charter has been updated following TAG proposal with adding amended text 
+**Resolution** 
+The Working Group has added expected progress status for these deliverables to the charter and 
+updated the "Status of this Document" section to provide clarity for developers and implementers.
+
+And the draft charter has been updated following TAG proposal with adding amended text 
 as `including for security and privacy enhancements`
 to enable modification of adding new feature specifically related to security and privacy enhancements, 
 at [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818), 
@@ -82,7 +87,12 @@ at [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818),
 **Response** The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
 the WG discussed on additional change over the PR, but did not resolved. 
 
-**Resolution** The draft charter has been updated following TAG proposal with integrating a change suggested by Anssi 
+**Resolution**
+The Working Group is committed to making appropriate tradeoffs between use cases and risks of abuse, as demonstrated by productive collaborations with privacy and security researchers and horizontal groups. This is codified in the Motivation and Background section.
+
+The Working Group continues to engage with non-participating browser engines as appropriate per the W3C Process.
+
+The draft charter has been updated following TAG proposal with integrating a change suggested by Anssi 
 to remove specifically mention to WebApps, and with adding links to the Process for making maturity level used in text clear, 
 by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
 
@@ -94,7 +104,12 @@ by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
 to add text not limited to the Vibration specification, but even further in relateion to TAG point 1, 
 the WG did not reached a concensus to accept or reject the PR.
 
-**Resolution** The draft charter has been updated following TAG porposal 
+**Resolution**
+The Working Group continues to follow the W3C Process when transitioning its deliverables from one maturity stage to another.
+
+The process changes drafted by the TAG are in the purview of the Process CG and the Advisory Board, to be discussed therein as appropriate. The Working Group does not adopt the proposed changes to the charter to ensure cohesion, separation of concerns and broad membership support for the procedures that govern the Working Groups.
+
+The draft charter has been updated following TAG porposal 
 with adding amended text to enable bringing specifications into CG as incubation along with publication as Discontinued Draft, 
 for making path clearer to continue incubation but not as completed end state, 
 by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819).
@@ -126,11 +141,14 @@ Christian Liebel confirmed [this point 4 has been resolved with set of PRs](http
 * https://github.com/w3c/ambient-light/pull/93
 
 
-#### Web Serial in tentative deliverables - Deferred
+#### Web Serial in tentative deliverables - Declined
 
 > We're concerned by the appearance of Web Serial in the [Tentative Deliverables](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html#tentative). At least Mozilla seems inclined to start implementing that API, and we want it to live in a WG that all implementers are comfortable joining, to ensure that all of their potential concerns about engine/platform capabilities, privacy, and security can be easily raised. That said, its presence in this charter doesn't prevent it from being adopted by another WG instead.
 
-**Response** Conversation held in [email thread](https://lists.w3.org/Archives/Public/www-archive/2026May/0000.html), 
+**Response** 
+The group has consensus to take up Mozilla's proposal to add Web Serial and other related specifications as a Tentative Deliverable in this Working Group. We also note that Mozilla has also started a parallel effort to create a WHATWG workstream for peripheral APIs. This may offer an alternative path for a forum that all implementers are comfortable joining.
+
+Conversation held in [email thread](https://lists.w3.org/Archives/Public/www-archive/2026May/0000.html), 
 no conclusion has made. 
 
 ### Other feedbacks on TAG review
@@ -162,7 +180,7 @@ no conclusion has made.
 > 
 > cc @reillyeon @jyasskin @anssiko @himorin
 
-by Marcos Cáceres, [w3c/charte-drafts #784](https://github.com/w3c/charter-drafts/pull/784)
+by Marcos Cáceres, [w3c/charte-drafts PR #784](https://github.com/w3c/charter-drafts/pull/784)
 
 **Resolution** Jeffrey Yasskin noted on this change that 
 `Here are my current thoughts on the proposal in this PR. This is not TAG consensus—it's just me so far. 
@@ -183,33 +201,6 @@ to come up in future design reviews for the individual specifications:
 > * Are the signals in the Battery API still the right ones to help websites help users achieve their goals? Would a "please reduce power use" signal be sufficient, with the UA in charge of deciding how the precise battery level and charging state contribute to that signal?
 
 **Response** The DAS WG noted these comments and continue onversation during further design review over each specification.
-
-#### Support level in status of specifications - Rejected
-
-> Status update: to implement the TAG's request that "each document's support level should be in its SotD section," I opened 11 PRs adding `.advisement` boxes to the SotD of each DAS WG spec. They have since been closed without discussion:
-> 
-> - [w3c/sensors#492](https://github.com/w3c/sensors/pull/492) — Generic Sensor API
-> - [w3c/accelerometer#84](https://github.com/w3c/accelerometer/pull/84)
-> - [w3c/gyroscope#65](https://github.com/w3c/gyroscope/pull/65)
-> - [w3c/magnetometer#77](https://github.com/w3c/magnetometer/pull/77)
-> - [w3c/ambient-light#92](https://github.com/w3c/ambient-light/pull/92)
-> - [w3c/orientation-sensor#86](https://github.com/w3c/orientation-sensor/pull/86)
-> - [w3c/proximity#62](https://github.com/w3c/proximity/pull/62)
-> - [w3c/compute-pressure#318](https://github.com/w3c/compute-pressure/pull/318)
-> - [w3c/battery#70](https://github.com/w3c/battery/pull/70)
-> - [w3c/device-posture#172](https://github.com/w3c/device-posture/pull/172)
-> - [w3c/vibration#57](https://github.com/w3c/vibration/pull/57)
-> 
-> For charter-level text, [charter-drafts#770](https://github.com/w3c/charter-drafts/pull/770) is in progress. [charter-drafts#784](https://github.com/w3c/charter-drafts/pull/784) proposes specific text addressing the TAG's concerns on SotD signalling, Vibration, and Generic Sensor framing, intended to land alongside #770. The remaining concerns are tracked in [#780](https://github.com/w3c/charter-drafts/issues/780), [#781](https://github.com/w3c/charter-drafts/issues/781), [#782](https://github.com/w3c/charter-drafts/issues/782), and [#783](https://github.com/w3c/charter-drafts/issues/783).
-> 
-> The TAG's concern that each document's support level should be in its SotD section remains open at the spec level, pending WG discussion.
-
-by Marcos Cáceres, in two comments ([first](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4159936835), 
-and [second](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-4163174410)) at w3ctag/design-reviews #1187.
-Also the same text has been posted by the same person to w3c/strategy #530 at 
-[first](https://github.com/w3c/strategy/issues/530#issuecomment-4159912174) and [second](https://github.com/w3c/strategy/issues/530#issuecomment-4163144358).
-
-**Response** the DAS WG closed opened PRs without merging for ongoing discussion during continuing charter refinement phase
 
 ## Other Strategy Issue Feedback
 

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -11,11 +11,17 @@ Comments were received through:
 
 ## Executive summary
 
+All comments received during the charter refinement phase of the Devices and Sensors Working Group charter 
+have been discussed, and some resulted to charter changes, some are marked as continuing discussion for 
+later discussion for entire W3C strategy or to allow the AC to weigh in discussion,  
+and some have not been rejected without change made. 
+
+Of the 19 comments (in category) received:
 
 * 5 were Accepted, and resulted in charter changes.
 * 3 were Accepted with amended text, and resulted in charter changes.
 * 6 were Noted, without requiring charter change.
-* 1 was Deferred, to later discussion for entire W3C strategy and investigation during specification development.
+* 1 was Deferred, to later discussion for entire W3C strategy.
 * 1 was Declined, to allow the AC to weigh in.
 * 2 were Rejected without change mage.
 * 1 was Won't fix.

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -68,13 +68,14 @@ and provided PRs for 4 points.
 
 > We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec is in Baseline. It makes sense to maintain non-consensus specifications while websites switch over to equivalent consensus APIs, but the charter should commit to only adding new features to the consensus versions. If there's not enough consensus on the new features to incorporate them into the core [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) spec, this WG could develop an extension specification that allows websites to mostly use the Baseline feature, with a few engine-specific extensions.
 
-**Response** The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
+**Response**
+The TAG opened a PR [w3c/charter-drafts PR #806](https://github.com/w3c/charter-drafts/pull/806), 
 the WG discussed on additional change over the PR but did not reach WG consensus. 
 
-**Resolution** 
 The Working Group has added expected progress status for these deliverables to the charter and 
 updated the "Status of this Document" section to provide clarity for developers and implementers.
 
+**Resolution** 
 And the draft charter has been updated following TAG proposal with adding amended text 
 as `including for security and privacy enhancements`
 to enable modification of adding new feature specifically related to security and privacy enhancements, 
@@ -84,14 +85,15 @@ at [w3c/charter-drafts PR #818](https://github.com/w3c/charter-drafts/pull/818),
 
 > We want to ensure that the other specifications fill clear user needs and are making appropriate tradeoffs between those user needs and any potential abuse of the APIs. In many WGs, we can rely on all 3 browser engines to check this, but since this WG does not currently include participation from all major browser engines, we're more concerned here. Could you add this goal to the charter for each of the specifications in that class? We see, for example, https://github.com/w3c/vibration/issues/45 to do this for Vibration, but it would be good to use the charter to ensure it gets done.
 
-**Response** The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
+**Response**
+The TAG opened a PR [w3c/charter-drafts PR #808](https://github.com/w3c/charter-drafts/pull/808), 
 the WG discussed on additional change over the PR, but did not resolved. 
 
-**Resolution**
 The Working Group is committed to making appropriate tradeoffs between use cases and risks of abuse, as demonstrated by productive collaborations with privacy and security researchers and horizontal groups. This is codified in the Motivation and Background section.
 
 The Working Group continues to engage with non-participating browser engines as appropriate per the W3C Process.
 
+**Resolution**
 The draft charter has been updated following TAG proposal with integrating a change suggested by Anssi 
 to remove specifically mention to WebApps, and with adding links to the Process for making maturity level used in text clear, 
 by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
@@ -105,18 +107,19 @@ Similar comments have been added to w3c/strategy #530, such as
 [comment](https://github.com/w3c/strategy/issues/530#issuecomment-4206018777),
 and [comment](https://github.com/w3c/strategy/issues/530#issuecomment-4210649633) by Marcos Cáceres. 
 
-**Response** The DAS WG resolved to add new implementation report for recently started Recommendation track specification 
+**Response**
+The DAS WG resolved to add new implementation report for recently started Recommendation track specification 
 from Candidate Resommendation Snapshot by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55). 
 
 The TAG opened a PR [w3c/charter-drafts PR #809](https://github.com/w3c/charter-drafts/pull/809) 
 to add text not limited to the Vibration specification, but even further in relateion to TAG point 1, 
 the WG did not reached a concensus to accept or reject the PR.
 
-**Resolution**
 The Working Group continues to follow the W3C Process when transitioning its deliverables from one maturity stage to another.
 
 The process changes drafted by the TAG are in the purview of the Process CG and the Advisory Board, to be discussed therein as appropriate. The Working Group does not adopt the proposed changes to the charter to ensure cohesion, separation of concerns and broad membership support for the procedures that govern the Working Groups.
 
+**Resolution**
 The draft charter has been updated following TAG porposal 
 with adding amended text to enable bringing specifications into CG as incubation along with publication as Discontinued Draft, 
 for making path clearer to continue incubation but not as completed end state, 
@@ -159,6 +162,11 @@ Christian Liebel confirmed [this point 4 has been resolved with set of PRs](http
 * https://github.com/w3c/gyroscope/pull/66
 * https://github.com/w3c/orientation-sensor/pull/87
 * https://github.com/w3c/ambient-light/pull/93
+
+Also the group maintains implementation status and standards positions in its 
+[wiki](https://www.w3.org/wiki/DAS/Implementations) and refers to 
+[wpt.fyi](https://wpt.fyi/) for test results. 
+These resources are referenced from the specification headers, as proposed by the TAG.
 
 
 #### Web Serial in tentative deliverables - Declined

--- a/2026/das-wg-charter-doc.md
+++ b/2026/das-wg-charter-doc.md
@@ -27,6 +27,10 @@ by Ruoxi Ran, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues
 
 by Simone Onofri, [w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-3848628218)
 
+**Response** The DAS WG appreciate the comment, and described situation in 
+[w3c/strategy #530 comment](https://github.com/w3c/strategy/issues/530#issuecomment-4569236084), that these are 
+[captured in Generic Sensors specification](https://w3c.github.io/sensors/#security-and-privacy) for sensor API specifications.
+
 ### Privacy - Noted
 
 > No concerns when discussed among chairs
@@ -73,7 +77,7 @@ the WG discussed on additional change over the PR, but did not resolved.
 
 **Resolution** The draft charter has been updated following TAG proposal with integrating a change suggested by Anssi 
 to remove specifically mention to WebApps, and with adding links to the Process for making maturity level used in text clear, 
-by [w3c/charter-drafts PR #821]
+by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
 
 #### Vibration API council concern - XXX
 
@@ -86,7 +90,7 @@ the WG did not reached a concensus to accept or reject the PR.
 **Resolution** The draft charter has been updated following TAG porposal 
 with adding amended text to enable bringing specifications into CG as incubation along with publication as Discontinued Draft, 
 for making path clearer to continue incubation but not as completed end state, 
-by [w3c/charter-drafts PR #821](https://github.com/w3c/charter-drafts/pull/821).
+by [w3c/charter-drafts PR #819](https://github.com/w3c/charter-drafts/pull/819).
 
 #### Support level in status section of specification - Accepted
 
@@ -292,6 +296,90 @@ by Marcos Cáceres, [w3c/charter-drafts #783](https://github.com/w3c/charter-dra
 **Response** Five specifications of Peripheral APIs has been kept within the draft charter, to allow AC to weigh in. 
 We note this disagreement on this resolution. 
 
+#### Implementation across platform families - Deferred 
+
+> Posting as W3C Member (not TAG Member).
+> 
+> The [DAS WG 2026 charter](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html) includes a number of specifications that are not implemented on all major platforms. The charter does not address whether these specifications are expected to be portable across platform families, or what cross-engine support means when some platforms do not implement them.
+> 
+> **Existing sensor specifications and the Generic Sensor architecture**
+> 
+> Accelerometer, Gyroscope, Magnetometer, Ambient Light Sensor, Proximity Sensor, and Orientation Sensor each extend the [Generic Sensor](https://www.w3.org/TR/generic-sensor/) API. Per MDN Browser Compat Data: Accelerometer, Gyroscope, and Orientation Sensor ship in Chrome (67+) only; Magnetometer and Ambient Light Sensor are in Chrome behind a flag; Proximity Sensor has no implementation in any browser (no BCD entry exists). None are implemented in Firefox or Safari.
+> 
+> Meanwhile, [Device Orientation and Motion](https://www.w3.org/TR/orientation-event/) covers the primary orientation and motion detection use cases with multi-engine support: per BCD, DeviceOrientationEvent ships in Chrome 7+, Edge 12+, Firefox 6+, Safari 17+ (including iOS Safari 4.2+). DeviceMotionEvent ships in Chrome 31+, Edge 12+, Firefox 6+, Safari 17+ (including iOS Safari 4.2+).
+> 
+> The Generic Sensor stack provides additional capabilities beyond Device Orientation (raw sensor readings, standalone Magnetometer access, Ambient Light, Proximity), but the charter does not explain which use cases require these additional capabilities, or why both architectures need to continue receiving new features given that the higher-level API has achieved broader cross-engine adoption.
+> 
+> The TAG's review ([design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187)) raised this concern directly:
+> 
+> > "We're concerned to see the Chromium-only Accelerometer, Gyroscope, and Orientation Sensor specifications in the charter, now that the Device Orientation and Motion spec is in Baseline."
+> 
+> **Tentative and proposed new deliverables**
+> 
+> Web Serial is a tentative deliverable. [PR #786](https://github.com/w3c/charter-drafts/pull/786) proposes adding Web Bluetooth and WebUSB as new tentative deliverables alongside Web Serial (which was already listed and is repositioned in the PR). These APIs expose raw transport protocols that are hardware-dependent by design. Per BCD, they ship only in Chromium-based browsers: Web Bluetooth (Chrome 70, Chrome Android 56), WebUSB (Chrome 61, Chrome Android 61), Web Serial (Chrome 89, Chrome Android 138), WebHID (Chrome 89, no Android support). Safari and Firefox do not implement them (Firefox BCD shows Web Serial at version 151, which is currently in beta, not yet in stable release).
+> 
+> The W3C [Ethical Web Principles](https://www.w3.org/TR/ethical-web-principles/#multi) (§2.11) state:
+> 
+> > "We will not create web technologies that encourage the creation of websites that work only in one browser, or only on particular hardware."
+> 
+> Does the charter expect these specifications to be portable across platform families? If not, how does the WG reconcile this with the principle above?
+
+by Marcos Cáceres, [w3c/charter-drafts #799](https://github.com/w3c/charter-drafts/issues/799)
+
+**Response** The DAS WG describes current implementation situation for sensor APIs, and demonstrated possibility of 
+implementation accross multiple platforms like over CPUs and SoCs.
+
+#### Potential security risk on sandbox escape via device APIs - Noted
+
+> Posting as W3C Member (not TAG Member).
+> 
+> The [DAS WG 2026 charter](https://w3c.github.io/charter-drafts/2026/das-wg-charter.html) states the WG is committed to "security and privacy focused" specification development and that:
+> 
+> > "APIs in scope that expose sensitive data will define normative mitigations to address any known security and privacy threats."
+> 
+> ["Peripheral Instinct: How External Devices Breach Browser Sandboxes"](https://misc0110.net/web/files/peripheralinstinct_www25.pdf) (Trampert et al., CISPA Helmholtz Center for Information Security and Universität des Saarlandes; WWW '25, ACM ISBN 979-8-4007-1274-6/25/04) is a peer-reviewed paper studying WebHID, WebUSB, Web Serial, and Web MIDI. From the abstract:
+> 
+> > "we build several full-chain exploits, leading to arbitrary code execution on the victim system, circumventing the browser sandbox."
+> 
+> Of the four APIs studied, Web Serial is a tentative deliverable of this WG, and WebUSB is proposed as a tentative deliverable via [PR #786](https://github.com/w3c/charter-drafts/pull/786). WebHID and Web MIDI are not in the charter but belong to the same class of device browser APIs.
+> 
+> Findings relevant to this charter:
+> 
+> **Web Serial** (tentative deliverable): the paper identifies "several potential threats that can be exploited by a malicious actor that can control a modem via the Web Serial API" (§7). These include: dialing or sending SMS to premium-rate numbers; accessing "sensitive information such as two-factor authentication codes or passwords" contained in SMS messages which "can even be intercepted by forwarding SMS messages and calls to the attacker's number" (§7); GPS tracking ("many modems contain a GPS module that allows the modem to determine its location, which allows tracking a user's location"); and permanent SIM card lockout ("PIN and PUK are entered using AT commands, which allows an attacker to perform a permanent DoS that locks the SIM card").
+> 
+> **WebHID**: "We investigate the features of 22 devices from 15 vendors" and found "reprogrammable on-board macro functionality supported by 14 devices" (§5.1.1). Configuration of the shortest malicious payload takes as little as ~20 ms (Table 2, Logitech G500s). The researchers built full exploit chains achieving arbitrary code execution on Windows (§6.1), macOS (Appendix D.2), and Linux (Appendix D.1).
+> 
+> **WebUSB**: the researchers "flash custom firmware on peripheral devices, such as the blink(1)" (a USB RGB LED notification light), "completely overtaking and repurposing the device" (§4.1). The paper describes the general attack pattern: "a non-input device can be maliciously repurposed as a keyboard, allowing attackers to inject arbitrary keystrokes into the system."
+> 
+> **Web MIDI**: "we can flash firmware on MIDI devices to repurpose them for malicious use cases" (abstract), demonstrated on the Launchpad MK2 MIDI controller where they "successfully patch the firmware achieving arbitrary code execution on the device" (§4.1).
+> 
+> **Permission model**: the paper cites Hazhirpasand et al. (2020), who "convinced up to 95 % of users into granting permissions leveraging a browser game" (§3.3). The paper notes: "Once permitted, the site can interact with the device without further consent on future visits" and that "an attacker can leverage permissions granted to another site via a Cross-Site Scripting (XSS), website compromise, or domain re-registration" (§3.3).
+> 
+> The paper concludes:
+> 
+> > "browser security should not rely on the secure implementation of third-party hardware"
+> 
+> and notes that the API specifications:
+> 
+> > "shift the responsibility to (unprepared) device vendors"
+> 
+> These findings suggest the current mitigation approach (permission prompts and blocklists) is insufficient for the threat model these APIs create, in which the host is a potentially malicious website rather than a trusted operating system. The charter does not acknowledge this changed threat model or explain how the WG's security approach addresses the class of attacks described above.
+> 
+> For reference, WebKit's published positions on the affected APIs:
+> - WebUSB: [oppose](https://github.com/WebKit/standards-positions/issues/68) (privacy, security, device independence)
+> - Web Bluetooth: [oppose](https://github.com/WebKit/standards-positions/issues/570) (privacy, security, device independence)
+> - Web Serial: [oppose](https://github.com/WebKit/standards-positions/issues/199) (privacy, security, device independence, use cases, venue)
+> - WebHID: [no position issued](https://github.com/WebKit/standards-positions/issues/510) (venue concern noted)
+
+by Marcos Cáceres, [w3c/charter-drafts #798](https://github.com/w3c/charter-drafts/issues/798)
+
+**Response** In specifications in CG space, these attack scenarios are largely acknowledged by the 
+"Security Considerations" sections of these specifications.
+
+**Resolution** Five specifications of Peripheral APIs has been kept within the draft charter, to allow AC to weigh in. 
+We note this disagreement on this resolution. 
+
+
 #### Remove potential joint deliverables for three Peripheral APIs - Accepted
 
 > Update the notes that indicate Web Bluetooth, Web Serial, and Web USB may become joint deliverables with the WebApps WG, since WebApps is unable to accept any more specifications at this time.
@@ -303,6 +391,15 @@ by Léonie Watson, [w3c/charter-drafts #810](https://github.com/w3c/charter-draf
 **Response** The draft charter has been updated by [w3c/charter-drafts PR #812](https://github.com/w3c/charter-drafts/pull/812) to align with this comment. 
 
 ### Comments related to implementation status and language
+
+#### Revise DAS WG charter with clearer implementation status - Accepted
+
+> Each deliverable gets an "implementation status" and "expected progress" section to document the current state as of the time of chartering and the work the group will do to advance each deliverable.
+
+by Reilly Grant, [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770)
+
+**Resolution** Although this change does not satisfy concerns of the TAG, this change has been integrated into 
+the draft DAS charter for better explanation. 
 
 #### Support level of specification in each status section - Accepted
 
@@ -327,5 +424,97 @@ by Léonie Watson, [w3c/charter-drafts #810](https://github.com/w3c/charter-draf
 by Marcos Cáceres, [issue raised as w3c/charter-drafts #780](https://github.com/w3c/charter-drafts/issues/780)
 
 **Response** Referenced PR [w3c/charter-drafts PR #770](https://github.com/w3c/charter-drafts/pull/770) has been integrated into the draft charter.
+
+#### Implementation report and WG plan for Vibration API - Won't fix
+
+> **Context:** This issue tracks concerns from both the W3C Council report and the TAG review of the 2026 DAS WG charter.
+> 
+? **W3C Council recommendation** (https://www.w3.org/2025/08/vibration2-council-report.html#recommendations, verbatim):
+> 
+> > "We recommend that the WG document what implementation experience the API currently has (issue 33). In the next rechartering process for the DAS WG, we anticipate that some W3C members will object to keeping a deliverable without a concrete plan and timeline for shipping in multiple major browser engines. We... recommend that the WG document the plan it thinks is best, whether or not that plan includes implementation in multiple browser engines, and a compelling rationale to help any reviewers decide whether the plan is acceptable."
+> 
+> **TAG review** (w3ctag/design-reviews#1187, charter-affecting section, verbatim):
+> 
+> > "We couldn't find such a plan in this rechartering effort, and we encourage the WG to write such plans for each single-engine specification, in order to head off this possible formal objection."
+> 
+> The current PR #770 adds the following "Expected progress" text for Vibration:
+> 
+> > "The Working Group will update the specification to modern web platform design principles and device haptics capabilities and continue to solicit feedback."
+> 
+> This does not constitute the plan the Council recommended. It contains no rationale, no criteria, and no timeline. Additionally, w3c/vibration#33 ("Update implementation report"), cited directly in the Council report, remains open as of this writing.
+> 
+> Before this charter proceeds to AC review, the charter should:
+> 1. Reference a publicly available document describing the WG's concrete plan for Vibration, with the rationale the Council requested.
+> 2. Commit to resolving w3c/vibration#33 (implementation report) before or during the charter review period.
+> 
+> *Note: The plan document itself need not appear in the charter — as discussed in PR #770, a reference to a published document is sufficient.*
+> 
+> Related: #770, w3ctag/design-reviews#1187, w3c/vibration#33
+
+by Marcos Cáceres, [issue raised as w3c/charter-drafts #781](https://github.com/w3c/charter-drafts/issues/781)
+
+**Response** Part of concern resolved by implementation report has been added by [w3c/vibration PR #55](https://github.com/w3c/vibration/pull/55).
+
+### Other comments
+
+#### Wrong listing of geolocation specification - Accepted
+
+> GeoLocation is under active development, so it should be moved out of the maintenance section into the normative specs section.
+> 
+> @himorin , @anssiko, @reillyeon, @w3c/marcomm, @siusin  
+
+by Léonie Watson, [w3c/charter-drafts #811](https://github.com/w3c/charter-drafts/issues/811)
+
+**Response** Error fixed by [w3c/charter-drafts PR #813](https://github.com/w3c/charter-drafts/pull/813)
+
+#### Mentioning Haptics in DAS charter - Accepted
+
+> **Note:** This concern is raised by @marcoscaceres in his personal capacity as a W3C member, not on behalf of the TAG. The TAG review (w3ctag/design-reviews#1187) was published before PR #770 introduced this specific language.
+> 
+> PR #770 adds the following "Expected progress" text for Vibration:
+> 
+> > "The Working Group will update the specification to modern web platform design principles and **device haptics capabilities** and continue to solicit feedback."
+> 
+> The phrase "device haptics capabilities" is problematic. The current Web Applications WG 2026 charter (https://www.w3.org/2026/01/webappswg-charter-2026.html) explicitly includes in its scope:
+> 
+> > "Haptic input devices and their emitted events and/or data."
+> 
+> And lists as a WICG deliverable:
+> 
+> > "Haptics — An API allowing web applications to interface with haptic actuators, such as vibration motors found on gamepad controllers, and potentially other devices that provide haptic feedback."
+> 
+> Haptics is not listed as a joint deliverable between DAS and WebApps in either the current WebApps charter or the DAS draft charter. WebApps and the Immersive Web CG are also actively exploring related work (see https://github.com/immersive-web/proposals/issues/92).
+> 
+> The DAS charter text must either:
+> 1. Confirm that Vibration remains a minimal primitive and explicitly remove the "device haptics capabilities" language, or
+> 2. Explicitly establish a joint deliverable arrangement with the Web Applications WG for any haptics-related work, with a clear statement of scope differentiation.
+> 
+> As written, the language signals unilateral expansion into an area that is already in scope of another WG, without a coordination model.
+> 
+> Additionally, the TAG review (charter-affecting section) specifically called out Vibration for needing better documentation of user needs and tradeoffs, citing w3c/vibration#45. That issue ("Create an explainer") remains open with no progress.
+> 
+> Related: #770, w3ctag/design-reviews#1187, w3c/vibration#45, https://github.com/immersive-web/proposals/issues/92
+
+by Marcos Cáceres, [issue raised as w3c/charter-drafts #782](https://github.com/w3c/charter-drafts/issues/782)
+
+**Response** The draft DAS charter has been updated by [w3c/charter-drafts #807](https://github.com/w3c/charter-drafts/pull/807). 
+
+#### Clarify haptics scope - Rejected
+
+Adding `semantic haptic feedback` into Scope, and `Gamepad haptics are out of scope for this WG` into Out of Scope
+
+by Anssi Kostiainen, [w3c/charter-drafts PR #816](https://github.com/w3c/charter-drafts/pull/816)
+
+**Resolution** This change has not been integrated into the draft DAS charter.
+
+#### Adding Web Haptics API, Revise DAS WG charter with a new deliverable proposed by Microsoft - Deferred
+
+Adding `Web Haptics API` into tentative deliverables.
+
+by Anssi Kostiainen, [w3c/charter-drafts PR #795](https://github.com/w3c/charter-drafts/pull/795)
+
+**Resolution** [Discussion has been postponed](https://github.com/w3c/charter-drafts/pull/795#issuecomment-4502569096), and 
+this change has not been integrated into the draft DAS charter. 
+And related issue `Venue and scope: Web Haptics API` has been filed at [w3c/charter-drafts 802#](https://github.com/w3c/charter-drafts/issues/802).
 
 


### PR DESCRIPTION
The disposition of comments summarizes high-level discussions that occurred during the charter refinement period, notes lack of consensus where appropriate, and contains links to issues for further details.