### PR TITLE
[wg/ag] Correction of 2 spelling mistakes in 3.5 - "consided" and "formated"

### DIFF
--- a/2025/ag-wg.html
+++ b/2025/ag-wg.html
@@ -355,7 +355,7 @@
             <li>Text of the requirement is complete</li>
             <li>At least one (informative) testing procedure is provided</li>
             <li>At least two (informative) methods are provided</li>
-            <li>At least one (informative) ACT formated rule is provided</li>
+            <li>At least one (informative) ACT formatted rule is provided</li>
           </ul>
 
           <p>Note that exploration for some of these topics may require a different publication approach to be taken. Where this occurs a group decision will be recorded in the group <a href="https://www.w3.org/WAI/GL/wiki/Decisions">Decision log</a>.</p>

--- a/2025/ag-wg.html
+++ b/2025/ag-wg.html
@@ -350,7 +350,7 @@
             <li>All issues raised against the guideline or provision have been closed or addressed for future fixes.</li>
           </ul>
 
-          <p>Additionally, requirement provisions content will be consided complete when:</p>
+          <p>Additionally, requirement provisions content will be considered complete when:</p>
           <ul>
             <li>Text of the requirement is complete</li>
             <li>At least one (informative) testing procedure is provided</li>


### PR DESCRIPTION
Typo discovered when responding to AC review of proposed charter.