### PR TITLE
[wg/ag] Update name of document referenced in 2.1 to match name that is set out in 3.5

### DIFF
--- a/2025/ag-wg.html
+++ b/2025/ag-wg.html
@@ -177,7 +177,7 @@
             <li>Informative user needs for each guideline,</li>
             <li>At least one method for each requirement, and</li>
             <li>At least one informative test for each requirement.</li>
-            <li>Additional informative reference documents to support WCAG 3, for example, "Standard keyboard navigation-operation keys and techniques".</li>
+            <li>Additional informative reference documents to support WCAG 3, for example, "Standard keyboard navigation and operation keys".</li>
           </ul>
 
           <p>WCAG 3.0 will provide as comprehensive a set of provisions for web technologies as possible. The provisions will also be written to apply to as wide a range of non-web technologies as possible (including platforms such as software and documents) but are not considered complete for those platforms in 3.0. Future versions may provide additional guidance specific to other types of digital content.</p>


### PR DESCRIPTION
Section 3.5 states "Work during this charter period should be considered done with the publication of the following materials as a minimum:" and then lists "Standard keyboard navigation and operation keys". as one of the materials to be published.

This should match the scope section (2.1) which currently states that "Additional informative reference documents to support WCAG 3, for example, "Standard keyboard navigation-operation keys and techniques"."
