### PR TITLE
[DAS charter] Add missing boilerplate text about Invited Experts

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -1256,6 +1256,9 @@
           Policy</a>.
         </p>
         <p>
+          The Chairs should periodically look through the non-W3C-Member contributors to the Working Group and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-W3C-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/das/instructions/">apply to be an Invited Expert</a>.
+        </p>
+        <p>
           Participants in the group are required (by the <a href=
           "https://www.w3.org/policies/process/#ParticipationCriteria">W3C 
           Process</a>) to follow the W3C <a href=


### PR DESCRIPTION
This adds the missing sentence from the charter template about periodically looking for non-W3C-Member contributors to the Working Group with a view to possibly extending an invitation to join as an Invited Expert.