### PR TITLE
[wg/webauthn] Threat Model requirement

### DIFF
--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -287,7 +287,8 @@ interoperability can be verified by passing open test suites. In order to advanc
     <!-- Horizontal review -->
 
     <p>Each specification should contain separate sections detailing all known security and
-      privacy implications for implementers, Web authors, and users.</p>
+      privacy implications for implementers, Web authors, and users.
+      The security considerations section must include a comprehensive threat model with threats, attacks, mitigations and residual threats.</p>
 
 	  <p id="a11y-section">
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and


### PR DESCRIPTION
This PR restores the explicit threat-model requirement in the Web Authentication Working Group charter.

It addresses part of https://github.com/w3c/strategy/issues/540#issuecomment-4653724403.

This change only restores the threat-model requirement.