### PR TITLE
[wg/atag] Update communication and decision policy

### DIFF
--- a/2026/atag-wg.html
+++ b/2026/atag-wg.html
@@ -318,8 +318,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           Most Authoring Tool Accessibility Guidelines Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.
         </p>
         <p>
-          This group primarily conducts its technical work  <i class="todo">pick one, or both, as appropriate:</i> on the public mailing list <a class="todo" id="public-name" href="mailto:public-atag-wg@w3.org">public-atag-wg@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-atag-wg/">archive</a>)
-          <i class="todo">or</i> on <a class="todo" id="public-github" href="https://github.com/w3c/atag/">GitHub issues</a>.
+          This group primarily conducts its technical work in a <a id="public-github" href="https://github.com/w3c/atag/">GitHub repository</a>.
           The public is invited to review, discuss and contribute to this work.
         </p>
         <p>
@@ -339,7 +338,7 @@ interoperability can be verified by passing open test suites. In order to advanc
         <p>
           To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
 
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from <span id='cfc' class="todo">5-10 working days</span>, depending on the chair's evaluation of the group consensus on the issue.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from one to two weeks, depending on the chair's evaluation of the group consensus on the issue.
 
           If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
         </p>


### PR DESCRIPTION
Refined a few items that were still marked “todo”.

Related to strategy issue https://github.com/w3c/strategy/issues/552