### PR TITLE
[wg/webauthn] Clarify WebAuthn Level 4 deliverable status

### DIFF
--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -222,16 +222,17 @@
                                             <dt id="webauthn-4" class="spec"><a href="https://www.w3.org/TR/webauthn-4/" rel="versionof">Web Authentication: An API for accessing Public Key Credentials - Level 4</a></dt>
                         <dd>
                             <p>This specification defines an API enabling the creation and use of strong, attested, scoped, public key-based credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more public key credentials, each scoped to a given WebAuthn Relying Party, are created by and bound to authenticators as requested by the web application. The user agent mediates access to authenticators and their public key credentials in order to preserve user privacy. Authenticators are responsible for ensuring that no operation is performed without user consent. Authenticators provide cryptographic proof of their properties to Relying Parties via attestation. This specification also describes the functional model for WebAuthn conformant authenticators, including their signature and attestation functionality.</p>
-                            <p><b>Draft state:</b> Candidate Recommendation</p>
-                            <p><b>Expected completion:</b> [Q4 2028]</p>
-                            <p><b>Latest publication:</b> <a href="https://www.w3.org/TR/2026/CR-webauthn-3-20260113/">2026-01-13</a></p>
-                            <p><b>Exclusion Draft:</b>
+                            <p><b>Draft state:</b> No First Public Working Draft published yet</p>
+                            <p><b>Expected completion:</b> Q4 2028</p>
+                            <p><b>Previous level:</b> Web Authentication Level 3 remains the current published Candidate Recommendation.</p>
+                            <p><b>Latest publication for the previous level:</b> <a href="https://www.w3.org/TR/2026/CR-webauthn-3-20260113/">2026-01-13</a></p>
+                            <p><b>Exclusion Draft for the previous level:</b>
                                 <a href="https://www.w3.org/TR/2026/CR-webauthn-3-20260113/">https://www.w3.org/TR/2026/CR-webauthn-3-20260113/</a><br>
                                 <a href="https://www.w3.org/mid/cfe-16484-828fd502f08fac5ac62fa65f28b8a2286b2c961a@w3.org">Exclusion period</a>
                                 began on 2026-01-13 and
                                 will end on 2026-03-14.
                             </p>
-                            <p><b>Exclusion Draft Charter</b>: Produced under Working Group Charter:
+                            <p><b>Exclusion Draft Charter for the previous level</b>: Produced under Working Group Charter:
                                                                     <a href="https://www.w3.org/2024/04/wg-webauthn-charter.html">https://www.w3.org/2024/04/wg-webauthn-charter.html</a>                                                            </p>
                         </dd>
                                         </dl>


### PR DESCRIPTION
This clarifies the WebAuthn deliverables section so the Level 4 entry does not read as if Level 4 is already in Candidate Recommendation.

The change marks Web Authentication Level 4 as having no First Public Working Draft published yet, identifies Web Authentication Level 3 as the current published Candidate Recommendation, and labels the latest publication and exclusion draft links as applying to the previous level.

This addresses review feedback in w3c/strategy#540 noting that the deliverables section lists Level 4 while the latest publication and exclusion draft links point to the Level 3 Candidate Recommendation.