### PR TITLE
[wg/webauthn] Clarify raw signing scope

### DIFF
--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -153,9 +153,9 @@
           </li><li>Storing of private key(s);
           </li><li>Account recovery and/or credential backup options;
           </li><li>Facilitate relying party adoption through additional API enhancements such as returning transport indications in assertions, a credential “durability” signal, and credential status feedback signaling from relying parties.
-          </li><li>Signing additional data beyond the standard authentication data. For example, to support use cases in the agentic AI and verifiable digital credential ecosystems;
+          </li><li>Signing additional data beyond the standard authentication data, including WebAuthn-mediated raw signing using signing keys associated with, but distinct from, WebAuthn credential keys. This supports scoped use cases such as agentic AI and verifiable digital credential ecosystems without exposing credential private key material to web applications;
           </li><li>Conveying additional trust signals about credential managers / authenticators;
-          </li><li>Enhancements to WebAuthn Extensions for confidentiality
+          </li><li>Enhancements to WebAuthn Extensions for confidentiality.
         </li></ol>
         <p>
           Dependencies may exist on
@@ -194,7 +194,8 @@
           <ul class="out-of-scope">
             <li>federated identity,</li>
             <li>multi-origin credentials,</li>
-            <li>low-level access to credential private key material.</li>
+            <li>low-level access to credential private key material;</li>
+            <li>standalone general-purpose cryptographic APIs or low-level cryptographic operations beyond the WebAuthn-mediated features explicitly listed in scope.</li>
           </ul>
         </section>
 

--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -153,7 +153,7 @@
           </li><li>Storing of private key(s);
           </li><li>Account recovery and/or credential backup options;
           </li><li>Facilitate relying party adoption through additional API enhancements such as returning transport indications in assertions, a credential “durability” signal, and credential status feedback signaling from relying parties.
-          </li><li>Signing additional data beyond the standard authentication data, including WebAuthn-mediated raw signing using signing keys associated with, but distinct from, WebAuthn credential keys. This supports scoped use cases such as agentic AI and verifiable digital credential ecosystems without exposing credential private key material to web applications;
+          </li><li>Signing additional data beyond the standard authentication data, including WebAuthn-mediated raw signing using signing keys associated with, but distinct from, WebAuthn credential keys. This enables hardware cryptography support for scoped use cases such as agentic AI and verifiable digital credential ecosystems without exposing credential private key material to web applications;
           </li><li>Conveying additional trust signals about credential managers / authenticators;
           </li><li>Enhancements to WebAuthn Extensions for confidentiality.
         </li></ol>


### PR DESCRIPTION
This clarifies the scope boundary for signing additional data in the Web Authentication Working Group charter.

The change makes explicit that WebAuthn-mediated raw signing is in scope when it uses signing keys associated with, but distinct from, WebAuthn credential keys. It also clarifies that this does not expose credential private key material to web applications.

The out-of-scope section is updated so standalone general-purpose cryptographic APIs and low-level cryptographic operations remain outside the charter, except for WebAuthn-mediated features explicitly listed in scope.

This addresses the raw-signing scope question raised in w3c/strategy#540.