### PR TITLE
[wg/webauthn] Clarify trust signal analysis scope

### DIFF
--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -154,7 +154,7 @@
           </li><li>Account recovery and/or credential backup options;
           </li><li>Facilitate relying party adoption through additional API enhancements such as returning transport indications in assertions, a credential “durability” signal, and credential status feedback signaling from relying parties.
           </li><li>Signing additional data beyond the standard authentication data. For example, to support use cases in the agentic AI and verifiable digital credential ecosystems;
-          </li><li>Conveying additional trust signals about credential managers / authenticators;
+          </li><li>Conveying additional trust signals about credential managers / authenticators, with analysis of the information exposed to Relying Parties, the criteria for admissible signals, limits on linkability and fingerprinting, and effects on privacy, user freedom, and centralization;
           </li><li>Enhancements to WebAuthn Extensions for confidentiality
         </li></ol>
         <p>


### PR DESCRIPTION
This updates the Web Authentication Working Group charter scope item for trust signals.

The change keeps trust signals in scope, but makes the expected analysis explicit: what information is exposed to Relying Parties, the criteria for admissible signals, limits on linkability and fingerprinting, and effects on privacy, user freedom, and centralization.

This is intended to address the trust-signal concerns raised in w3c/strategy#540, while keeping the charter text aligned with the CMTG explainer and avoiding scope creep into a general device trust or integrity API.
