### PR TITLE
[wg/webperf] Change to address formal objection from AC review

### DIFF
--- a/2026/webperf-wg-charter.html
+++ b/2026/webperf-wg-charter.html
@@ -490,7 +490,8 @@ interoperability can be verified by passing open test suites. In order to advanc
     </ul>
 
     <!-- Relevance and momentum -->
-	  <p>New features that do not have support from at least two implementers will be incorporated into the draft specifications with an annotation of their experimental or optional status.</p>
+	  <p>All new features should have expressions of interest from at least two implementors before being incorporated in the specifications. Features that do not have two intents to implement will be incorporated into Candidate Recommendation drafts with an annotation of their at-risk status. </p>                                                                      
+            
 	</section>
 
       <section id="coordination">

--- a/2026/webperf-wg-charter.html
+++ b/2026/webperf-wg-charter.html
@@ -490,7 +490,7 @@ interoperability can be verified by passing open test suites. In order to advanc
     </ul>
 
     <!-- Relevance and momentum -->
-	  <p>All new features should have expressions of interest from at least two implementors before being incorporated in the specifications. Features that do not have two intents to implement will be incorporated into Candidate Recommendation drafts with an annotation of their at-risk status. </p>                                                                      
+	  <p>All new features should have expressions of interest from at least two implementors before being incorporated in the specifications. Features that do not have two intents to implement may be incorporated into Candidate Recommendation drafts and must include an annotation of their at-risk status. </p>                                                                      
             
 	</section>
 

--- a/2026/webperf-wg-charter.html
+++ b/2026/webperf-wg-charter.html
@@ -181,8 +181,6 @@
           
         <p>The Working Group intends to publish the latest state of their work as Candidate Recommendations, upgrading specifications with Candidate Recommendation Snapshots. Alternatively, ongoing work may be published as Recommendations to be updated further with Candidate Changes.</p>
 
-        <p>The Working Group expects to gradually move all of its deliverables to this model. Beyond that, the WG expects to converge at least some of its deliverables into a smaller number of specifications.</p>
-
         <section id="normative">
           <h3>
             Normative Specifications
@@ -490,7 +488,7 @@ interoperability can be verified by passing open test suites. In order to advanc
     </ul>
 
     <!-- Relevance and momentum -->
-	  <p>All new features should have expressions of interest from at least two implementors before being incorporated in the specifications. Features that do not have two intents to implement may be incorporated into Candidate Recommendation drafts and must include an annotation of their at-risk status. </p>                                                                      
+	  <p>All new features should have expressions of interest from at least two implementors before being incorporated in specifications maintained as Candidate Recommendations. Features that do not have at least two expressions of interest from implementers may be incorporated into Candidate Recommendation drafts and must include an annotation of their at-risk status. </p>                                                                      
             
 	</section>
 


### PR DESCRIPTION
This change reintroduce a sentence similar to the charter template for every WG maintaining living CRs.  A second sentence similar to the deleted text clarifies that it is still possible to have only one intent to implement when adding a feature, with the precaution of identifying it as "at risk"

cc https://github.com/w3c/strategy/issues/531