### PR TITLE
[wg/browser-tools-testing] Drop AT Driver deliverable

### DIFF
--- a/2026/charter-wg-btt.html
+++ b/2026/charter-wg-btt.html
@@ -7,15 +7,15 @@
     <link rel="stylesheet" type="text/css" href="https://www.w3.org/2026/01/charter-style.css">
     <meta name="generator" content="w3c-charter-assistant">
     <script type="application/json" id="charter-assistant-settings">{
-      "group": "wg/browser-tools-testing",
-      "workMode": "cr-snapshot",
-      "a11y-impact": "false",
-      "template": {
-        "sha": "b43b4eb5f52bb0fee2beeb8e98f8266e9ef6ad77",
-        "date": "2026-01-29T10:38:13Z"
-      },
-      "timeStamp": "2026-04-15T09:24:40.288Z"
-    }</script>
+  "group": "wg/browser-tools-testing",
+  "workMode": "cr-snapshot",
+  "a11y-impact": "false",
+  "template": {
+    "sha": "5d95fbad34407c9a976e09e51959a0c97c590cb9",
+    "date": "2026-07-03T16:44:03Z"
+  },
+  "timeStamp": "2026-04-15T09:24:40.288Z"
+}</script>
     <script src="https://www.w3.org/PM/Groups/lib/check-charter.js" type="module" id="charter-assistant-checker"></script>
   </head>
   <body>
@@ -190,11 +190,6 @@
               <p><b>Exclusion Draft Charter</b>: Produced under Working Group Charter:
                                                         <a href="https://www.w3.org/2024/btt-wg-charter.html">https://www.w3.org/2024/btt-wg-charter.html</a>                                                            </p>
             </dd>
-            <dt id="at-driver" class="spec"><a href="https://w3c.github.io/at-driver/">AT Driver</a></dt>
-            <dd>
-              <p>AT Driver defines a protocol for introspection and remote control of assistive technology (AT) such as screen readers, using a bidirectional communication channel.</p>
-              <p class="draft-status"><b>Draft state:</b> <a href="https://w3c.github.io/at-driver/">Editor's Draft</a></p>
-            </dd>
           </dl>
         </section>
 
@@ -320,7 +315,6 @@
         <ul>
           <li><a href="https://github.com/w3c/webdriver">WebDriver spec repo</a></li>
           <li><a href="https://github.com/w3c/webdriver-bidi">WebDriver BiDi spec repo</a></li>
-          <li><a href="https://github.com/w3c/at-driver">AT-Driver spec repo</a></li>
         </ul>
         <p>
           The public is invited to review, discuss and contribute to this work.
@@ -565,7 +559,7 @@
                   <i class="todo">[dd monthname yyyy] (Start date + 2 years)</i>
                 </td>
                 <td>
-                  Content aligned with charter template. No changes in scope or deliverables.
+                  Content aligned with charter template. AT Driver deliverable dropped.
                 </td>
               </tr>
             </tbody>

--- a/2026/charter-wg-btt.html
+++ b/2026/charter-wg-btt.html
@@ -264,6 +264,8 @@
             <dt><a href="https://www.w3.org/groups/wg/apa/">Accessible Platform Architectures Working Group</a></dt>
             <dd>This group ensures W3C specifications provide support for accessibility to people with disabilities, and
               there is a possibility of relevant accessibility considerations in APIs for browser testing.</dd>
+            <dt><a href="https://www.w3.org/groups/wg/aria/">ARIA Working Group</a></dt>
+            <dd>This group develops supplemental attributes that can be applied to native host language interactive elements and exposed via platform accessibility application programming interfaces (APIs). The Browser Testing and Tools Working Group will coordinate with the ARIA Working Group on the <a href="https://w3c.github.io/at-driver/">AT Driver</a> specification that used to be in scope of the Browser Testing and Tools Working Group and that the ARIA Working Group may adopt when it recharters.</dd>
           </dl>
         </section>
 


### PR DESCRIPTION
There is not enough support from for keeping the deliverable in the group for now. See discussion in https://github.com/w3c/strategy/issues/558#issuecomment-4604831970 for a plan to have the deliverable adopted by the ARIA WG when it recharters.