### PR TITLE
[wg/webauthn] Clarify testing deliverables

### DIFF
--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -246,11 +246,15 @@
             Other Deliverables
           </h3>
           <p>
+            The Working Group will maintain its test suite in the
+            <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a>
+            project and produce an implementation report for each normative specification.
+          </p>
+          <p>
             Other non-normative documents may be created such as:
           </p>
           <ul>
             <li>Use case and requirement documents;</li>
-            <li>Test suite and implementation report for the specification;</li>
             <li>Primer or Best Practice documents to support web developers when designing applications.</li>
           </ul>
         </section>


### PR DESCRIPTION
This clarifies the testing deliverables in the Web Authentication Working Group charter.

The change makes explicit that the Working Group maintains its interoperability test suite in Web Platform Tests and produces an implementation report for each normative specification. It moves this work out of the list of optional non-normative documents and does not introduce a FIDO certification deliverable.

This addresses the testing discussion in w3c/strategy#540, in line with https://github.com/w3c/strategy/issues/540#issuecomment-4443498533.