### PR TITLE
clean-up

### DIFF
--- a/2026/charter-wg-webauthn-2026.html
+++ b/2026/charter-wg-webauthn-2026.html
@@ -28,7 +28,6 @@
           <li><a href="#decisions">Decision Policy</a></li>
           
           <li><a href="#patentpolicy">Patent Policy</a></li>
-          <li></li>
           <li><a href="#licensing">Licensing</a></li>
           <li><a href="#about">About this Charter</a></li>
         </ul>
@@ -98,7 +97,7 @@
             <th>
               Team Contacts
             </th>
-            <td><a href="mailto:simone@w3.org">Simone Onofri</a> <i class="todo">(0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)</i></td>
+            <td><a href="mailto:simone@w3.org">Simone Onofri</a> (0.05 <abbr title="Full-Time Equivalent">FTE</abbr>)</td>
           </tr>
           <tr id="MeetingSchedule">
             <th>
@@ -182,8 +181,6 @@
           credentials should be taken into account. The Working Group may produce protocol
           standards as needed by the API.
         </p>
-        <p>
-        </p>
         <section id="section-out-of-scope">
           <h3 id="out-of-scope">Out of Scope</h3>
           <p>
@@ -208,7 +205,7 @@
 
         <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/webauthn/publications/">group publication status page</a>.</p>
 
-        <p id="draft-state"><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <span class="todo">Choose one:</span> <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
+        <p id="draft-state"><i>Draft state</i> indicates the state of the deliverable at the time of the charter approval. <i>Expected completion</i> indicates when the deliverable is projected to become a Recommendation, or otherwise reach a stable state.</p>
 
         <section id="normative">
           <h3>
@@ -225,8 +222,8 @@
                             <p>This specification defines an API enabling the creation and use of strong, attested, scoped, public key-based credentials by web applications, for the purpose of strongly authenticating users. Conceptually, one or more public key credentials, each scoped to a given WebAuthn Relying Party, are created by and bound to authenticators as requested by the web application. The user agent mediates access to authenticators and their public key credentials in order to preserve user privacy. Authenticators are responsible for ensuring that no operation is performed without user consent. Authenticators provide cryptographic proof of their properties to Relying Parties via attestation. This specification also describes the functional model for WebAuthn conformant authenticators, including their signature and attestation functionality.</p>
                             <p><b>Draft state:</b> No First Public Working Draft published yet</p>
                             <p><b>Expected completion:</b> Q4 2028</p>
-                            <p><b>Previous level:</b> Web Authentication Level 3 remains the current published Candidate Recommendation.</p>
-                            <p><b>Latest publication for the previous level:</b> <a href="https://www.w3.org/TR/2026/CR-webauthn-3-20260113/">2026-01-13</a></p>
+                            <p><b>Previous level:</b> Web Authentication Level 3 remains the current published Candidate Recommendation and is undergoing Advisory Committee review for transition to Recommendation.</p>
+                            <p><b>Latest publication for the previous level:</b> <a href="https://www.w3.org/TR/2026/CR-webauthn-3-20260526/">2026-05-26</a></p>
                             <p><b>Exclusion Draft for the previous level:</b>
                                 <a href="https://www.w3.org/TR/2026/CR-webauthn-3-20260113/">https://www.w3.org/TR/2026/CR-webauthn-3-20260113/</a><br>
                                 <a href="https://www.w3.org/mid/cfe-16484-828fd502f08fac5ac62fa65f28b8a2286b2c961a@w3.org">Exclusion period</a>
@@ -259,18 +256,6 @@
           </ul>
         </section>
 
-        <section id="timeline">
-          <h3>Timeline</h3>
-            <p class="todo">Put here a timeline view of all deliverables.</p>
-            <ul class="todo">
-              <li>Month YYYY: First teleconference</li>
-              <li>Month YYYY: First face-to-face meeting</li>
-              <li>Month YYYY: Requirements and Use Cases for FooML</li>
-              <li>Month YYYY: FPWD for FooML</li>
-              <li>Month YYYY: Requirements and Use Cases for BarML</li>
-              <li>Month YYYY: FPWD FooML Primer</li>
-            </ul>
-        </section>
       </section>
 
 	<section id="success-criteria">
@@ -349,10 +334,10 @@ interoperability can be verified by passing open test suites. In order to advanc
             </dd><dt><a href="https://www.w3.org/groups/wg/apa/">Accessible Platform Architectures Working Group</a></dt>
             <dd>Coordination to review accessibility requirements for APIs and for any direct user interfaces that may be specified.
             </dd>
-            </dd><dt><a href="https://www.w3.org/groups/wg/fedid/">Federated Identity Working Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/wg/fedid/">Federated Identity Working Group</a></dt>
             <dd>Coordination on related identity and authentication specifications like the Digital Credentials API and Federated Credential Management API.
             </dd>
-            </dd><dt><a href="https://www.w3.org/groups/cg/wica/">Web Identity and Credentials Community Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/cg/wica/">Web Identity and Credentials Community Group</a></dt>
             <dd>Coordination on developer guidance for Web Authentication and related specifications, and on use cases and requirements for future API features.
             </dd>
           </dl></section>
@@ -380,7 +365,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href="#communication">Communication</a>. The group also welcomes non-participants to make technical contributions for ongoing work, provided they agree to the terms of the <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a>.
         </p>
         <p>
-          The Chairs should periodically look through the non-W3C-Member contributors to the Working Groupand consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-W3C-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/webauthn/instructions/">apply to be an Invited Expert</a>.
+          The Chairs should periodically look through the non-W3C-Member contributors to the Working Group and consider whether each one should be invited to participate as an <a href="https://www.w3.org/invited-experts/">Invited Expert</a>. If a non-W3C-Member contributor would like to participate in meetings, they are encouraged to <a href="https://www.w3.org/groups/wg/webauthn/instructions/">apply to be an Invited Expert</a>.
         </p>
         <p>Participants in the group are required (by the <a href="https://www.w3.org/policies/process/#ParticipationCriteria">W3C Process</a>) to follow the
           W3C <a href="https://www.w3.org/policies/code-of-conduct/">Code of Conduct</a>.</p>
@@ -474,7 +459,7 @@ interoperability can be verified by passing open test suites. In order to advanc
           <h3>
             Charter History
           </h3>
-          <p class="issue"><b>Note:</b>Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
+          <p class="issue"><b>Note:</b> Display this table and update it when appropriate. Requirements for charter extension history are documented in the <a href="https://www.w3.org/Guide/process/charter.html#extension">Charter Guidebook (section 4)</a>.</p>
 
           <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/policies/process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
 
@@ -620,21 +605,6 @@ interoperability can be verified by passing open test suites. In order to advanc
                   Drop DiD WG coordination.
                 </td>
               </tr>
-              <tr>
-                <th>
-                  <span class="todo"><a href="#">Rechartered</a></span>
-                </th>
-                <td>
-                  <span class="todo">30 April 2026</span>
-                </td>
-                <td>
-                  <span class="todo">30 April 2028</span>
-                </td>
-                <td>
-                  <span class="todo">@@</span>
-                </td>
-              </tr>
-
             </tbody>
           </table>
         </section>


### PR DESCRIPTION
Updates the 2026 Web Authentication Working Group charter to reflect the current WebAuthn Level 3 status and remove remaining template and markup artifacts.

The change:

- records that Level 3 is in Advisory Committee review for transition to Recommendation and links its 26 May 2026 Candidate Recommendation;
- restores the Team Contact allocation from the previous charter;
- removes placeholder timeline and recharter-history content;
- fixes invalid HTML structure and editorial typos.

It does not change group coordination, scope, or the `residual threats` terminology.
