### PR TITLE
[wg/atag] Fix link to Web & AI Interest Group

### DIFF
--- a/2026/atag-wg.html
+++ b/2026/atag-wg.html
@@ -271,7 +271,7 @@ interoperability can be verified by passing open test suites. In order to advanc
             <dd>The ATAG Working Group will coordinate with the Timed Text Working Group to ensure guidance is inclusive of use cases in the media ecosystem and reflects the requirements or best practices for media production.</dd>
           </dl>
           <dl>
-            <dt><a href="https://www.w3.org/groups/ig//">Web & AI Interest Group</a></dt>
+            <dt><a href="https://www.w3.org/groups/ig/webai/">Web & AI Interest Group</a></dt>
             <dd>The ATAG Working Group will coordinate with the Web & AI Interest Group on AI-related aspects of its work, including any use cases and developments to consider.</dd>
           </dl>
           <dl>


### PR DESCRIPTION
The group shortname was missing in https://github.com/w3c/charter-drafts/pull/857

Related to strategy issue https://github.com/w3c/strategy/issues/552