### PR TITLE
[wg/immersive-web] Aligned spec description to ones' abstract

### DIFF
--- a/2026/iwwg-charter.html
+++ b/2026/iwwg-charter.html
@@ -344,8 +344,7 @@
           <dt id="webxr-lighting-estimation" class="spec"><a href="https://immersive-web.github.io/lighting-estimation/"
               target="_blank">WebXR Lighting Estimation API Level 1</a></dt>
           <dd>
-            <p>This specification enables developers to render augmented reality content that reacts to real world
-              lighting with the WebXR Device API and the WebXR AR Module.</p>
+            <p>This specification describes support for exposing estimates of environmental lighting conditions to WebXR sessions.</p>
             <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-lighting-estimation-1/"
                 target="_blank">Working Draft</a></p>
             <p class="milestone"><b>Expected completion:</b> <i class="todo">Q4 2026</i></p>
@@ -366,7 +365,7 @@
           <dt id="webxr-hand-input" class="spec"><a href="https://immersive-web.github.io/webxr-hand-input/"
               target="_blank">WebXR Hand Input Module - Level 1</a></dt>
           <dd>
-            <p>This specification defines a method for enabling hand input to be used with the WebXR Device API.</p>
+            <p>The WebXR Hand Input module expands the WebXR Device API with the functionality to track articulated hand poses.</p>
             <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-hand-input-1/"
                 target="_blank">Working Draft</a></p>
             <p class="milestone"><b>Expected completion:</b> <i class="todo">Q4 2026</i></p>
@@ -403,8 +402,7 @@
           <dt id="webxr-layers" class="spec"><a href="https://immersive-web.github.io/layers/" target="_blank">WebXR
               Layers API Level 1</a></dt>
           <dd>
-            <p>This specification defines methods for manipulating composition layers used with the WebXR Device API.
-            </p>
+            <p>This specification describes support for various layer types used in a WebXR session.</p>
             <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxrlayers-1/"
                 target="_blank">Working Draft</a></p>
             <p class="milestone"><b>Expected W3C Recommendation:</b> yearly basis (living specification)</p>
@@ -425,7 +423,7 @@
 
         <dt id="depth-sensing" class="spec"><a href="https://immersive-web.github.io/depth-sensing/">WebXR Depth Sensing Module</a></dt>
         <dd>
-          <p>This feature would provide depth and occlusion data on AR devices.</p>
+          <p>Depth Sensing API enables apps to obtain depth information computed by supported XR devices in order to provide more immersive experiences.</p>
           <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-depth-sensing-1/">Working 
               Draft</a></p>
           <p class="milestone"><b>Expected completion:</b> <i class="todo">Q4 2026</i></p>
@@ -461,8 +459,7 @@
           <dt id="webxr-plane-detection" class="spec"><a
               href="https://immersive-web.github.io/plane-detection/">WebXR Plane Detection Module</a></dt>
           <dd>
-            <p>This specification enables access to real world geometry like planes and meshes to be used with the WebXR
-              AR Module. It is possible this module will be split into multiple deliverables.</p>
+            <p>Plane Detection module extends the capabilities of the WebXR Device API to enable apps to receive the set of planes detected by the native XR devices in order to enable more immersive experiences.</p>
             <p class="draft-status"><b>Draft state:</b> Adopted from <a href="https://www.w3.org/community/immersive-web/">the Immersive Web CG</a></p>
             <p class="milestone"><b>Expected completion:</b> <i class="todo">Q4 2026</i></p>
             <p><b>Adopted Editors' Draft:</b> <a href="https://immersive-web.github.io/plane-detection/"
@@ -472,7 +469,7 @@
           <dt id="raw-camera-access" class="spec"><a href="https://immersive-web.github.io/raw-camera-access/">WebXR Raw
               Camera Access Module</a></dt>
           <dd>
-            <p>This feature would enable predictable access to camera frame data for AR devices.</p>
+            <p>This specification provides a means to access the raw camera image displayed behind an immerisve-ar session, when the device is responsible for rendering that camera image.</p>
             <p class="draft-status"><b>Draft state:</b> Adopted from <a href="https://www.w3.org/community/immersive-web/">the Immersive Web CG</a></p>
             <p class="milestone"><b>Expected completion:</b> <i class="todo">Q4 2026</i></p>
             <p><b>Adopted Editors' Draft:</b> Adopted from <a href="https://immersive-web.github.io/raw-camera-access/">the Immersive Web CG</a></p>

--- a/2026/iwwg-charter.html
+++ b/2026/iwwg-charter.html
@@ -1101,6 +1101,7 @@
                 </td>
                 <td>
                   <p>Added: WebXR/WebGPU Binding Module</p>
+				  <p>Renamed: Depth/Occlusion API to WebXR Depth Sensing Module, WebXR Real World Geometry Module to WebXR Plane Detection Module (mesh part moved to WebXR Mesh Detection Module in tentative deliverables)</p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
As title, aligning spec description in draft charter to abstract in specifications.


/cc @AdaRoseCannon @Yonet

@alcooper91  For anchors, it seems [text in draft charter](https://w3c.github.io/charter-drafts/2026/iwwg-charter.html#webxr-anchors) is more descriptive than [one in Abstract](https://immersive-web.github.io/anchors/#abstract), keep current in spec or write some more using text in draft charter?