### PR TITLE
[wg/immersive-web] Adding tentative deliverables section for clarification

### DIFF
--- a/2026/iwwg-charter.html
+++ b/2026/iwwg-charter.html
@@ -487,6 +487,12 @@
           </dd>
         </dl>
 
+	  </section><!-- id normative -->
+
+      <section id="incubation">
+          <h3>
+            Tentative Deliverables
+          </h3>
         <p>
           The Working Group also intends to work on the following Recommendation-Track deliverables, although it
           recognizes these


### PR DESCRIPTION
(this may or may not be merged after discussion with co-chairs)

including "Tentative Deliverables" section from [charter template](https://w3c.github.io/charter-drafts/charter-template.html#incubation), to clarify specifications under CG and incubation.
leading text of target section remains, since it has more clarification than one in template.

/cc @AdaRoseCannon @Yonet