### PR TITLE
[ig/security] editorial: fix links to charter/issues ig-security.html

### DIFF
--- a/2026/ig-security.html
+++ b/2026/ig-security.html
@@ -57,9 +57,9 @@
       <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
       <!-- delete the whole paragraph after AC review completed -->
       <p class="issue"> This proposed charter is available
-      on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/charter-template.html?todo=@@">GitHub</a>.
+      on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/2026/ig-security.html">GitHub</a>.
 
-    Feel free to raise <a href="https://github.com/w3c/charter-drafts/issues?q=is%3Aissue%20state%3Aopen%20label%3Atemplate&amp;todo=@@">issues</a></i>.
+    Feel free to raise <a href="https://github.com/w3c/strategy/issues?q=is%3Aissue%20state%3Aopen%20%22%5Big%2Fsecurity%5D%22">issues</a></i>.
           </p>
 
       <div id="details">

--- a/2026/ig-security.html
+++ b/2026/ig-security.html
@@ -54,7 +54,6 @@
       </div>
 
       <!-- replace "draft charter" with "proposed charter" when the AC review starts -->
-      <!-- replace GitHub link and issues link to the specific charter in GH and its issues repo -->
       <!-- delete the whole paragraph after AC review completed -->
       <p class="issue"> This proposed charter is available
       on <i class="todo"><a href="https://github.com/w3c/charter-drafts/blob/gh-pages/2026/ig-security.html">GitHub</a>.


### PR DESCRIPTION
fixed the template links to charter/issues to link directly to ig-security.html in the repo and [ig/security] open issues