### PR TITLE
[ig/security] add WHATWG to External Orgs ig-security.html

### DIFF
--- a/2026/ig-security.html
+++ b/2026/ig-security.html
@@ -232,7 +232,7 @@
             <dt><a href="https://whatwg.org/">WHATWG</a></dt><dd>Coordinate with WHATWG workstreams, such as HTML and DOM, on security reviews of their specifications.</dd>
 			<dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
             <dt><a href="https://isecom.org">ISECOM</a></dt><dd>Coordinate with ISECOM for security research methodologies.</dd>
-	        <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
+	          <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
             <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
             <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
             <dt><a href="https://owasp.org">OWASP</a></dt><dd>Coordinate with OWASP for application security requirements and testing methodologies.</dd>

--- a/2026/ig-security.html
+++ b/2026/ig-security.html
@@ -229,9 +229,10 @@
 
 
         <h3 id="external-coordination">External Organizations</h3><p>W3C needs to coordinate with other security groups, alliances, and standards development organizations to improve the Web's security. The following list provides examples of organizations:</p><dl>
-            <dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
+            <dt><a href="https://whatwg.org/">WHATWG</a></dt><dd>Coordinate with WHATWG workstreams, such as HTML and DOM, on security reviews of their specifications.</dd>
+			<dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
             <dt><a href="https://isecom.org">ISECOM</a></dt><dd>Coordinate with ISECOM for security research methodologies.</dd>
-	          <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
+	        <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
             <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>
             <dt><a href="https://openssf.org">OpenSSF</a></dt><dd>Coordinate with OpenSSF for Open Source Security aspects.</dd>
             <dt><a href="https://owasp.org">OWASP</a></dt><dd>Coordinate with OWASP for application security requirements and testing methodologies.</dd>


### PR DESCRIPTION
similar to exiting External Organization Coordination with the IETF, add WHATWG workstreams in general, with examples of HTML and DOM, for security reviews of their specifications, like other horizontal review group charters as noted in https://github.com/w3c/strategy/issues/568#issuecomment-5500232971

* https://www.w3.org/2023/07/apa-wg-charter#external-coordination
* https://www.w3.org/International/groups/wg/charter.html#external-coordination
* https://www.w3.org/2024/10/wg-privacy-charter.html#external-coordination