### PR TITLE
[ig/security] Add WHATWG coordination

### DIFF
--- a/2026/ig-security.html
+++ b/2026/ig-security.html
@@ -230,6 +230,7 @@
 
         <h3 id="external-coordination">External Organizations</h3><p>W3C needs to coordinate with other security groups, alliances, and standards development organizations to improve the Web's security. The following list provides examples of organizations:</p><dl>
             <dt><a href="https://www.ietf.org">IETF</a></dt><dd>Coordinate with the IETF research groups and working groups, such as SecDir and CFRG, for security review activities. </dd>
+            <dt><a href="https://whatwg.org/">WHATWG</a></dt><dd>Coordinate with WHATWG on security aspects of Web specifications.</dd>
             <dt><a href="https://isecom.org">ISECOM</a></dt><dd>Coordinate with ISECOM for security research methodologies.</dd>
 	          <dt><a href="https://ecma-international.org/task-groups/tc39-tg3/">TC39-TG3</a></dt><dd>Coordinate with TC39-TG3 on ECMAScript® (JavaScript™) security model aspects.</dd>
             <dt><a href="https://openjsf.org">OpenJS Foundation</a></dt><dd>Coordinate with OpenJS Foundation for JavaScript security aspects.</dd>


### PR DESCRIPTION
Adds WHATWG to the Security Interest Group charter’s External Organizations and identifies coordination on security aspects of Web specifications.

This addresses [the charter refinement comment in w3c/strategy#568](https://github.com/w3c/strategy/issues/568#issuecomment-5500232971).