### PR TITLE
[wg/das] Drop the Peripheral APIs

### DIFF
--- a/2026/das-wg-charter.html
+++ b/2026/das-wg-charter.html
@@ -153,7 +153,7 @@
               Team Contact
             </th>
             <td rowspan="1" colspan="1">
-              Atsushi Shimono (0.2 <abbr title="Full-Time Equivalent">FTE</abbr>))
+              Atsushi Shimono (0.1 <abbr title="Full-Time Equivalent">FTE</abbr>))
             </td>
           </tr>
           <tr>
@@ -882,36 +882,6 @@
           Depending on the progress, including consideration for adequate implementation experience, the Group may also produce W3C Recommendations for the following documents:
         </p>
         <dl>
-          <dt><a href="https://webbluetoothcg.github.io/web-bluetooth/">Web Bluetooth</a></dt>
-          <dd>
-            <p>An API to discover and communicate with devices over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT).</p>
-            <p><b>Draft state</b>: Draft Community Group Report</p>
-            <p><b>Adopted Draft</b>: <a href="https://webbluetoothcg.github.io/web-bluetooth/">Adopted from Web Bluetooth Community Group</a></p>
-          </dd>
-          <dt><a href="https://wicg.github.io/serial/">Web Serial</a></dt>
-          <dd>
-            <p>An API for reading and writing from a serial device through script.</p>
-            <p><b>Draft state</b>: Draft Community Group Report</p>
-            <p><b>Adopted Draft</b>: <a href="https://wicg.github.io/serial/">Adopted from WICG</a></p>
-          </dd>
-          <dt><a href="https://wicg.github.io/webusb/">WebUSB</a></dt>
-          <dd>
-            <p>An API for reading and writing from a USB device through script.</p>
-            <p><b>Draft state</b>: Draft Community Group Report</p>
-            <p><b>Adopted Draft</b>: <a href="https://wicg.github.io/webusb/">Adopted from WICG</a></p>
-          </dd>
-          <dt><a href="https://w3c-cg.github.io/web-nfc/">Web NFC</a></dt>
-          <dd>
-            <p>An API to enable selected use cases based on NFC technology, with current scope as NDEF.</p>
-            <p><b>Draft state</b>: Draft Community Group Report</p>
-            <p><b>Adopted Draft</b>: <a href="https://w3c-cg.github.io/web-nfc/">Adopted from Web NFC Community Group</a></p>
-          </dd>
-          <dt><a href="https://wicg.github.io/webhid/">WebHID API</a></dt>
-          <dd>
-            <p>An API for providing access to devices that support the Human Interface Device (HID) protocol.</p>
-            <p><b>Draft state</b>: Draft Community Group Report</p>
-            <p><b>Adopted Draft</b>: <a href="https://wicg.github.io/webhid/">Adopted from WICG</a></p>
-          </dd>
           <dt>
             <a href="https://wicg.github.io/netinfo/">Network Information
             API</a>
@@ -1567,8 +1537,6 @@
                   <br/>Added plan for deliverables shipping in a single browser engine.
                   <br/>Moved Geolocation API and Vibration API to list of normative deliverables.
                   <br/>Moved discontinued Geolocation Sensor to maintenance.
-                  <br/>Added 5 peripheral APIs as tentative deliverables (Web Bluetooth, Web Serial, WebUSB, Web NFC, WebHID).
-                  <br/>Increased team support from 0.1 FTE to 0.2 FTE.
                 </td>
               </tr>
           </tbody>


### PR DESCRIPTION
A new Peripheral APIs workstream was created in the WHATWG to develop the 5 Peripheral APIs that were also under discussion for addition in scope of the Devices and Sensors Working Group, see:
https://whatwg.org/workstreams
https://github.com/whatwg/sg/pull/264

There is no consensus in the Devices and Sensors Working Group to drop the APIs but it would not make sense to duplicate work across organizations. This update drops the APIs from the proposed charter accordingly. Given the lower number of deliverables, the update also rolls back the Team Contact time to 0.10 FTE.